### PR TITLE
Update README to specify use of `bundle exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@
 ###### Local Dev
 
 1. Clone this repo
-    ```shellsession
+    ```bash
 $ git clone git@github.com:cul-it/mann-wagon.git
 ```
 
 1. Install gems
-   ```shellsession
+   ```bash
 $ cd <clone>
 $ bundle install
 ```
 
 1. Serve the site
-   ```shellsession
+   ```bash
 $ bundle exec wagon serve -v
 ```
 
@@ -39,12 +39,12 @@ Add `email` and `api_key` for development environment
 
 ###### Sync from a remote Engine
 
-```shellsession
-$ wagon sync development
+```bash
+$ bundle exec wagon sync development
 ```
 
 ###### Deploy to a remote Engine
 
-```shellsession
-$ wagon deploy development
+```bash
+$ bundle exec wagon deploy development
 ```


### PR DESCRIPTION
Goes a long way to ensure the correct and expected version of wagon is
being used.

Also update syntax highlighter for code snippets to `bash` alias.