### PR TITLE
New releases of wagon(rc6), steam(rc9) & coal(rc4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'locomotivecms_wagon', '2.0.0.rc5'
+gem 'locomotivecms_wagon', '~> 2.0.0.rc6'
 gem 'celluloid', '0.16.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     locomotivecms-liquid (4.0.0)
     locomotivecms-solid (4.0.1)
       locomotivecms-liquid (~> 4.0.0)
-    locomotivecms_coal (1.0.0.rc3)
+    locomotivecms_coal (1.0.0.rc4)
       activesupport (~> 4.2.3)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.10.0)
@@ -82,7 +82,7 @@ GEM
       attr_extras (~> 4.4.0)
       colorize
       stringex (~> 2.5.2)
-    locomotivecms_steam (1.0.0.rc8)
+    locomotivecms_steam (1.0.0.rc9)
       RedCloth (~> 4.2.9)
       chronic (~> 0.10.2)
       coffee-script (~> 2.4.1)
@@ -107,12 +107,12 @@ GEM
       sprockets (~> 2.12.3)
       sprockets-less (~> 0.6.1)
       sprockets-sass (~> 1.3.1)
-    locomotivecms_wagon (2.0.0.rc5)
+    locomotivecms_wagon (2.0.0.rc6)
       faker (~> 1.4.3)
       listen (~> 3.0.4)
-      locomotivecms_coal (~> 1.0.0.rc3)
+      locomotivecms_coal (~> 1.0.0.rc4)
       locomotivecms_common (~> 0.0.5)
-      locomotivecms_steam (~> 1.0.0.rc7)
+      locomotivecms_steam (~> 1.0.0.rc9)
       netrc (~> 0.10.3)
       rack-livereload (~> 0.3.16)
       rubyzip (~> 1.1.7)
@@ -185,7 +185,7 @@ DEPENDENCIES
   bitters
   bourbon
   celluloid (= 0.16.0)
-  locomotivecms_wagon (= 2.0.0.rc5)
+  locomotivecms_wagon (~> 2.0.0.rc6)
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Relevant diffs:
* [wagon rc5 --> rc6](https://github.com/locomotivecms/wagon/compare/6a30532...4cc0a47)
* [steam rc8 --> rc9](https://github.com/locomotivecms/steam/compare/v1.0.0.rc8...v1.0.0.rc9)
* [coal rc3 --> rc4](https://github.com/locomotivecms/coal/compare/v1.0.0.rc3...v1.0.0.rc4)