### PR TITLE
Add URL for NYCCSC project

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -3,22 +3,22 @@
     _slug: teeal
     title: TEEAL
     description: "<p>Description goes here<br></p>"
-    url : http://www.teeal.org/
+    url : http://www.teeal.org
     featured: true
 - VIVO:
     _slug: vivo
     title: VIVO
     description: "<p>Description goes here</p>"
-    url : http://vivo.cornell.edu/
+    url : http://vivo.cornell.edu
     featured: true
 - NYCCSC:
     _slug: nyccsc
     title: NYCCSC
     description: "<p>Description goes here<br></p>"
-    url : #
+    url : http://climate.library.cornell.edu
     featured: true
 - EarthCube:
     _slug: earthcube
     title: EarthCube
-    url : http://earthcube.org/
+    url : http://earthcube.org
     description: "<p>Description goes here<br></p>"


### PR DESCRIPTION
Projects content type defines URL field as required. This was preventing a `wagon deploy -d` (deploying data).

Also clipped trailing slash from existing URLs for other projects.