### PR TITLE
Initial go at template for site search

### DIFF
--- a/app/views/pages/search.liquid
+++ b/app/views/pages/search.liquid
@@ -14,26 +14,42 @@ published: true
     <input class="js-site-search__input" type="text" name="q" value="{{ params.q }}">
   </form>
 
+  {% comment %} Build the request string using API key stored in site metafield {% endcomment %}
+  {% assign api_request_url = 'https://storage.scrapinghub.com/items/54745/1/2?format=json&apikey=' %}
+  {% assign api_request_url = api_request_url | append: site.metafields.sensitive_data.scrapinghub_apikey %}
+
   {% comment %} Render results only if search query exists {% endcomment %}
   {% if params.q %}
-    {% comment %} Build the request string using API key stored in site metafield {% endcomment %}
-    {% assign api_request_url = 'https://storage.scrapinghub.com/items/54745/1/2?format=json&apikey=' %}
-    {% assign api_request_url = api_request_url | append: site.metafields.sensitive_data.scrapinghub_apikey %}
-
     {% consume portia from api_request_url , expires_in: 600 %}
       {% if portia == null %}
         Search is currently unavailable.
       {% else %}
+        {% comment %} Initiate counter {% endcomment %}
+        {% assign results_counter = 0 %}
+
         <ol class="site-search__results">
           {% for result in portia %}
-            <li class="site-search__result">
-              <h3 class="site-search__page-title"><a href="{{result.url}}">{{ result.page_title[0] }}</a></h3>
+            {% comment %} Lowercase everything since `contains` is case sensitive {% endcomment %}
+            {% assign q_dcase = params.q | downcase %}
+            {% assign page_title_dcase = result.page_title[0] | downcase %}
+            {% assign page_content_dcase = result.page_content[0] | downcase %}
 
-              <p>{{ result.page_content[0] | truncatewords: 12 }}<p>
-            </li>
+            {% comment %} What do you think of dem apples, Google? {% endcomment %}
+            {% if page_title_dcase contains q_dcase or page_content_dcase contains q_dcase %}
+              <li class="site-search__result">
+                <h3 class="site-search__page-title"><a href="{{result.url}}">{{ result.page_title[0] }}</a></h3>
+
+                <p class="site-search__page-content">{{ result.page_content[0] | truncatewords: 24 }}<p>
+              </li>
+
+              {% capture results_counter %}{{ results_counter | plus: 1 }}{% endcapture %}
+            {% endif %}
           {% endfor %}
         </ol>
-        {% comment %}{{ portia }}{% endcomment %}
+
+        {% if results_counter == 0 %}
+          <div class="site-search__no-results flash-notice">No results</div>
+        {% endif %}
       {% endif %}
     {% endconsume %}
   {% endif %}

--- a/app/views/pages/search.liquid
+++ b/app/views/pages/search.liquid
@@ -1,0 +1,42 @@
+---
+title: Search
+slug: search
+handle: search
+listed: false
+published: true
+---
+{% extends layouts/default %}
+
+{% block main %}
+
+<div class="site-search">
+  <form class="site-search__trigger" action="{{ path }}">
+    <input class="js-site-search__input" type="text" name="q" value="{{ params.q }}">
+  </form>
+
+  {% comment %} Render results only if search query exists {% endcomment %}
+  {% if params.q %}
+    {% comment %} Build the request string using API key stored in site metafield {% endcomment %}
+    {% assign api_request_url = 'https://storage.scrapinghub.com/items/54745/1/2?format=json&apikey=' %}
+    {% assign api_request_url = api_request_url | append: site.metafields.sensitive_data.scrapinghub_apikey %}
+
+    {% consume portia from api_request_url , expires_in: 600 %}
+      {% if portia == null %}
+        Search is currently unavailable.
+      {% else %}
+        <ol class="site-search__results">
+          {% for result in portia %}
+            <li class="site-search__result">
+              <h3 class="site-search__page-title"><a href="{{result.url}}">{{ result.page_title[0] }}</a></h3>
+
+              <p>{{ result.page_content[0] | truncatewords: 12 }}<p>
+            </li>
+          {% endfor %}
+        </ol>
+        {% comment %}{{ portia }}{% endcomment %}
+      {% endif %}
+    {% endconsume %}
+  {% endif %}
+</div>
+
+{% endblock %}

--- a/app/views/snippets/header.liquid.haml
+++ b/app/views/snippets/header.liquid.haml
@@ -20,8 +20,8 @@
         .text Catalog
         %i.dropdown.icon
         .menu
-          .item.js-search-target{data: {action: "http://search.library.cornell.edu"}} Catalog
-          .item.js-search-target{data: {action: "http://duckduckgo.com"}} Website
+          .item.js-search-target{data: {action: "http://search.library.cornell.edu", target: "_blank"}} Catalog
+          .item.js-search-target{data: {action: "/search", target: "_self"}} Website
 
   .todays-hours
     %ul

--- a/config/metafields_schema.yml
+++ b/config/metafields_schema.yml
@@ -1,0 +1,62 @@
+# Site metafield schema
+#
+# Syntax:
+#
+# <namespace_1>: # no empty spaces, only digits and underscores
+#   label: <my label> # used as the label of a tab in the back-office
+#   # label: # if you want to provide the label in another language (back-office)
+#   #   en: <your label in English if the local of the current user is English>
+#   #   fr: <your label in French>
+#   position: <0..n> # position of the tab in the menu
+#   fields:
+#     <name_1>:
+#       label: <my label> # used as the label of the HTML input. Use a hash if you want it in another languages.
+#       hint: <my hint> # used as the hint of the HTML input. Use a hash if you want it in another languages.
+#       type: <string|text|integer|float|file|image|boolean|select|color>
+#       localized: <true|false> # if the value is scoped by the current locale when rendering the site.
+#       position: <0..n> # position of the input in the form
+#       select_options: [array]
+#       # select_options:
+#       #   <option_value_1>: <label> # use a hash instead if you want it in another languages.
+#       #   <option_value_2>: <label> # use a hash instead if you want it in another languages.
+#     # <name_2>:
+#     #   ...
+#
+# <namespace_2>:
+#   # ...
+#
+#
+# Simple example:
+#
+# shop:
+#   label: My shop location
+#   fields:
+#     address:
+#       type: string
+#       hint: "Ex: 7 allee Albert Camus"
+#     city:
+#       type: string
+#       hint: "Chicago, Paris, Blagnac, Toulouse"
+#     zip_code:
+#       type: string
+#       hint: "Digits only"
+#     hours:
+#       type: text
+#       hint: "Free text here"
+# theme:
+#   fields:
+#     background_image:
+#       type: image
+#       hint: full screen image (min: 3000px x 3000px)
+#     link_color:
+#       type: color
+#     font:
+#       type: select
+#       select_options: ['helvetica', 'Noto']
+
+sensitive_data:
+  label: Sensitive Data
+  fields:
+    scrapinghub_apikey:
+      type: string
+      hint: Used to retrieve the items scraped from dev site to power temporary site search

--- a/public/javascripts/search-select.js
+++ b/public/javascripts/search-select.js
@@ -2,7 +2,15 @@ $('.ui.dropdown')
   .dropdown()
 ;
 
-// Set form action for search (catalog or website)
+// Set form action & target for search (catalog or website)
 $('.js-search-target').click(function() {
-  $('.search').attr('action', $(this).data("action"));
+  $('.search').attr({
+    action: $(this).data("action"),
+    target: $(this).data("target")
+  });
+
+  // If a query string has already been entered, GO!
+  if ( $('.search__term').val() ) {
+    $('.search').submit();
+  }
 });

--- a/public/stylesheets/components/_site-search.scss
+++ b/public/stylesheets/components/_site-search.scss
@@ -1,0 +1,15 @@
+.site-search {
+  @include span(full);
+}
+
+.site-search__results {
+  padding-left: 1em;
+  list-style-type: decimal;
+}
+
+.site-search__page-title {
+  margin: 1em 0 0 0;
+  font-family: $base-font-family;
+  font-weight: 700;
+  font-size: modular-scale(0);
+}

--- a/public/stylesheets/components/_site-search.scss
+++ b/public/stylesheets/components/_site-search.scss
@@ -3,13 +3,24 @@
 }
 
 .site-search__results {
+  margin-top: 1.5em;
   padding-left: 1em;
   list-style-type: decimal;
+
+  @include span(full);
 }
 
 .site-search__page-title {
   margin: 1em 0 0 0;
   font-family: $base-font-family;
   font-weight: 700;
-  font-size: modular-scale(0);
+}
+
+.site-search__page-content {
+  color: color('medium-gray');
+}
+
+.site-search__no-results {
+  margin-top: 1.5em;
+  text-align: left;
 }

--- a/public/stylesheets/main.scss
+++ b/public/stylesheets/main.scss
@@ -36,6 +36,7 @@
 @import 'components/search';
 @import 'components/section-nav';
 @import 'components/space-finder';
+@import 'components/site-search';
 @import 'components/todays-hours';
 
 @import 'pages/home';


### PR DESCRIPTION
Using the `consume` tag and no filtering happening just yet. Lodash is up next
but for now any search term will return all results.

Didn't want to commit the API key for scrapinghub, so I decided to experiment
with the new metafields feature that's upcoming with v3.1. Very nice...very
nice...