### PR TITLE
Update to wagon v2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'locomotivecms_wagon', '2.1.0.rc5'
+gem 'locomotivecms_wagon', '2.1.0'
 gem 'celluloid', '0.16.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       attr_extras (~> 4.4.0)
       colorize
       stringex (~> 2.6.0)
-    locomotivecms_steam (1.1.0.rc3)
+    locomotivecms_steam (1.1.0)
       RedCloth (~> 4.2.9)
       autoprefixer-rails (~> 6.3.3.1)
       chronic (~> 0.10.2)
@@ -104,12 +104,12 @@ GEM
       sanitize (~> 4.0.1)
       sass (~> 3.4.21)
       sprockets (~> 3.5.2)
-    locomotivecms_wagon (2.1.0.rc5)
+    locomotivecms_wagon (2.1.0)
       faker (~> 1.6)
       listen (~> 3.0.4)
       locomotivecms_coal (~> 1.1.0)
       locomotivecms_common (~> 0.1.0)
-      locomotivecms_steam (~> 1.1.0.rc3)
+      locomotivecms_steam (~> 1.1.0)
       netrc (~> 0.10.3)
       rack-livereload (~> 0.3.16)
       rubyzip (~> 1.1.7)
@@ -169,7 +169,7 @@ PLATFORMS
 
 DEPENDENCIES
   celluloid (= 0.16.0)
-  locomotivecms_wagon (= 2.1.0.rc5)
+  locomotivecms_wagon (= 2.1.0)
   mann_liquid_extensions!
 
 BUNDLED WITH


### PR DESCRIPTION
Just released yesterday, 4/21/16. Also includes latest steam v1.1.0 as
dependency.