### PR TITLE
Unignore public/javascripts/vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ npm-debug.log
 # Vendorized Sass
 public/stylesheets/vendor/*
 !public/stylesheets/vendor/.gitkeep
-
-#Vendorized Vue
-public/javascripts/vendor/*

--- a/public/javascripts/eventsPage.bundle.js
+++ b/public/javascripts/eventsPage.bundle.js
@@ -11837,7 +11837,7 @@
 	  var hotAPI = require("vue-hot-reload-api")
 	  hotAPI.install(require("vue"), true)
 	  if (!hotAPI.compatible) return
-	  var id = "/Users/tap87/Sites/mann-wagon/vue/events/events-page/components/Events.vue"
+	  var id = "./Events.vue"
 	  if (!module.hot.data) {
 	    hotAPI.createRecord(id, module.exports)
 	  } else {
@@ -12197,7 +12197,7 @@
 	  var hotAPI = require("vue-hot-reload-api")
 	  hotAPI.install(require("vue"), true)
 	  if (!hotAPI.compatible) return
-	  var id = "/Users/tap87/Sites/mann-wagon/vue/events/events-page/components/Description.vue"
+	  var id = "./Description.vue"
 	  if (!module.hot.data) {
 	    hotAPI.createRecord(id, module.exports)
 	  } else {

--- a/public/javascripts/homePageEvents.bundle.js
+++ b/public/javascripts/homePageEvents.bundle.js
@@ -42077,7 +42077,7 @@
 	  var hotAPI = require("vue-hot-reload-api")
 	  hotAPI.install(require("vue"), true)
 	  if (!hotAPI.compatible) return
-	  var id = "/Users/tap87/Sites/mann-wagon/vue/events/homepage-events/components/HomepageEvents.vue"
+	  var id = "./HomepageEvents.vue"
 	  if (!module.hot.data) {
 	    hotAPI.createRecord(id, module.exports)
 	  } else {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,6 @@ module.exports = {
       eventsPage: "./vue/events/events-page/events-page.js",
       homePageEvents: "./vue/events/homepage-events/homepage-events.js"
   },
-
-  // Vendorize the mixins & libraries
   output: {
     path: path.join(__dirname, 'public', 'javascripts'),
     filename: "[name].bundle.js",
@@ -35,6 +33,7 @@ module.exports = {
         }
       ]
     },
+  // Vendorize the Sass mixins & libraries
   plugins: [
     new CopyWebpackPlugin([
       // Accoutrement Color


### PR DESCRIPTION
No longer necessary since Vue and rest of JS are not being vendorized now thanks
to vue-loader (#313) and webpack.