### PR TITLE
Update to vue-loader v8.5.1 as minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "susy": "^2.2.12",
     "vue-hot-reload-api": "^1.3.2",
     "vue-html-loader": "^1.2.2",
-    "vue-loader": "^8.3.1",
+    "vue-loader": "^8.5.1",
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.13.0"
   },


### PR DESCRIPTION
This is the latest release that includes the merged PR for relative paths.