### PR TITLE
Bump to latest wagon 2.2.0.rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source 'https://rubygems.org'
 
-# Temporarily using GitHub repos to accommodate LabStats API
-# https://github.com/locomotivecms/steam/pull/67
-gem 'locomotivecms_steam', :github => 'cappadona/steam', :branch => 'dev'
-gem 'locomotivecms_wagon', :github => 'locomotivecms/wagon'
-# gem 'locomotivecms_wagon', '2.1.0'
+gem 'locomotivecms_wagon', '~> 2.2.0.rc1'
 gem 'celluloid', '0.16.0'
 
 # Local development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,52 +1,4 @@
 GIT
-  remote: git://github.com/cappadona/steam.git
-  revision: 1324391f333f0bec72e392d0e6d02a624915ca8a
-  branch: dev
-  specs:
-    locomotivecms_steam (1.2.0.beta1)
-      RedCloth (~> 4.2.9)
-      autoprefixer-rails (~> 6.3.3.1)
-      chronic (~> 0.10.2)
-      coffee-script (~> 2.4.1)
-      compass (~> 1.0.3)
-      dragonfly (~> 1.0.12)
-      duktape (~> 1.3.0.6)
-      httparty (~> 0.13.6)
-      kramdown (~> 1.10.0)
-      locomotivecms-solid (~> 4.0.1)
-      locomotivecms_common (~> 0.2.0)
-      mime-types (~> 2.6.1)
-      mimetype-fu (~> 0.1.2)
-      moneta (~> 0.8.0)
-      morphine (~> 0.1.1)
-      nokogiri (~> 1.6.7.2)
-      pony (~> 1.11)
-      rack-cache (~> 1.6.1)
-      rack-rewrite (~> 1.5.1)
-      rack_csrf (~> 2.5.0)
-      sanitize (~> 4.0.1)
-      sass (~> 3.4.21)
-      sprockets (~> 3.5.2)
-
-GIT
-  remote: git://github.com/locomotivecms/wagon.git
-  revision: be8467e7f54ffe2144d16c0c8afd528048fd7bcd
-  specs:
-    locomotivecms_wagon (2.2.0.beta1)
-      faker (~> 1.6)
-      haml (~> 4.0.7)
-      listen (~> 3.0.4)
-      locomotivecms_coal (~> 1.2.0)
-      locomotivecms_common (~> 0.2.0)
-      locomotivecms_steam (~> 1.2.0.beta)
-      netrc (~> 0.10.3)
-      rack-livereload (~> 0.3.16)
-      rubyzip (~> 1.1.7)
-      thin (~> 1.6.3)
-      thor (~> 0.19.1)
-      yui-compressor (~> 0.12.0)
-
-GIT
   remote: git@github.com:cul-it/mann_liquid_extensions
   revision: 8b0cb08633d7b0fe8a7d66264f3904f6e23dd7bc
   ref: 8b0cb08
@@ -56,8 +8,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    RedCloth (4.2.9)
-    activesupport (4.2.6)
+    RedCloth (4.3.2)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -75,7 +27,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    colorize (0.7.7)
+    colorize (0.8.1)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -90,7 +42,7 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.2)
     crass (1.0.2)
-    daemons (1.2.3)
+    daemons (1.2.4)
     dragonfly (1.0.12)
       addressable (~> 2.3)
       multi_json (~> 1.0)
@@ -98,13 +50,13 @@ GEM
     duktape (1.3.0.6)
     eventmachine (1.2.0.1)
     execjs (2.7.0)
-    faker (1.6.3)
+    faker (1.6.6)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.10)
+    ffi (1.9.14)
     haml (4.0.7)
       tilt
     hitimes (1.2.4)
@@ -121,7 +73,7 @@ GEM
     locomotivecms-liquid (4.0.0)
     locomotivecms-solid (4.0.1)
       locomotivecms-liquid (~> 4.0.0)
-    locomotivecms_coal (1.2.0)
+    locomotivecms_coal (1.3.0.rc1)
       activesupport (~> 4.2.6)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.10.0)
@@ -131,11 +83,48 @@ GEM
       attr_extras (~> 4.4.0)
       colorize
       stringex (~> 2.6.0)
+    locomotivecms_steam (1.2.0.rc1)
+      RedCloth (~> 4.3.2)
+      autoprefixer-rails (~> 6.3.3.1)
+      chronic (~> 0.10.2)
+      coffee-script (~> 2.4.1)
+      compass (~> 1.0.3)
+      dragonfly (~> 1.0.12)
+      duktape (~> 1.3.0.6)
+      httparty (~> 0.13.6)
+      kramdown (~> 1.10.0)
+      locomotivecms-solid (~> 4.0.1)
+      locomotivecms_common (~> 0.2.0)
+      mime-types (~> 2.6.1)
+      mimetype-fu (~> 0.1.2)
+      moneta (~> 0.8.0)
+      morphine (~> 0.1.1)
+      nokogiri (~> 1.6.8)
+      pony (~> 1.11)
+      rack-cache (~> 1.6.1)
+      rack-rewrite (~> 1.5.1)
+      rack_csrf (~> 2.5.0)
+      sanitize (~> 4.0.1)
+      sass (~> 3.4.21)
+      sprockets (~> 3.5.2)
+    locomotivecms_wagon (2.2.0.rc1)
+      faker (~> 1.6)
+      haml (~> 4.0.7)
+      listen (~> 3.0.4)
+      locomotivecms_coal (~> 1.3.0.rc1)
+      locomotivecms_common (~> 0.2.0)
+      locomotivecms_steam (~> 1.2.0.rc1)
+      netrc (~> 0.10.3)
+      rack-livereload (~> 0.3.16)
+      rubyzip (~> 1.1.7)
+      thin (~> 1.6.3)
+      thor (~> 0.19.1)
+      yui-compressor (~> 0.12.0)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     mime-types (2.6.2)
     mimetype-fu (0.1.2)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.9.0)
     moneta (0.8.0)
     morphine (0.1.1)
@@ -143,10 +132,12 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     netrc (0.10.3)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
-    nokogumbo (1.4.7)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    nokogumbo (1.4.9)
       nokogiri
+    pkg-config (1.1.7)
     pony (1.11)
       mail (>= 2.0)
     rack (1.6.4)
@@ -169,7 +160,7 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    stringex (2.6.0)
+    stringex (2.6.1)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -188,8 +179,7 @@ PLATFORMS
 
 DEPENDENCIES
   celluloid (= 0.16.0)
-  locomotivecms_steam!
-  locomotivecms_wagon!
+  locomotivecms_wagon (~> 2.2.0.rc1)
   mann_liquid_extensions!
 
 BUNDLED WITH


### PR DESCRIPTION
This, in turn, depends on latest steam 1.2.0.rc1, which includes both of our
merged PRs:

* Authorization header for consume tag (locomotivecms/steam#67)

* Request referer in global drop (locomotivecms/steam#73)