### PR TITLE
Delay reveal of megamenu by 200ms & add down caret

### DIFF
--- a/app/views/snippets/nav-megamenu.liquid
+++ b/app/views/snippets/nav-megamenu.liquid
@@ -1,7 +1,7 @@
 {% comment %} Snippet that builds array of sub-pages for spaces {% endcomment %}
 {% include 'spaces-subnav' %}
 
-{{ page.title }}</a>
+{{ page.title }} <i class="fa fa-caret-down"></i></a>
 
 <ul class="site-nav__mega">
   {% for child in page.children %}

--- a/src/scss/layout/_nav.scss
+++ b/src/scss/layout/_nav.scss
@@ -164,13 +164,17 @@
 
     &:hover {
       background: color('vulcan');
+      transition-delay: 200ms;
 
       & > a {
         color: color('nav');
+        transition-delay: 200ms;
       }
 
       & > .site-nav__mega {
-        display: block;
+        visibility: visible;
+        opacity: 1;
+        transition-delay: 200ms;
       }
 
     }
@@ -193,10 +197,11 @@
     width: 86vw;
   }
 
-  display: none;
   position: absolute;
   top: 100%;
   left: 0;
+  visibility: hidden;
+  opacity: 0;
   z-index: $above-content;
   background: color('vulcan' ('transparentize': .02));
   padding: 2em;


### PR DESCRIPTION
This is a very quick & simple first attempt to address the number one issue we
observed in multiple rounds of usability testing where users were inadvertently
triggering the megamenu as the moved the cursor past the top level pages in the
navigation. As described in #451.

This current implementation is problematic on touch devices, so rest assured
this is not the final approach.