### PR TITLE
Workshops nav shuffle

### DIFF
--- a/app/views/pages/help/research-support/workshops.liquid
+++ b/app/views/pages/help/research-support/workshops.liquid
@@ -4,7 +4,6 @@ slug: workshops
 position: 6
 listed: true
 published: true
-redirect_url: "/news-events/workshops-and-classes/workshop-selections"
 is_layout: false
 ---
 {% extends 'layouts/basic-page' %}

--- a/app/views/pages/layouts/section.liquid
+++ b/app/views/pages/layouts/section.liquid
@@ -1,6 +1,6 @@
 ---
-title: Section New
-is_layout: false
+title: Section
+is_layout: true
 ---
 {% extends 'layouts/default' %}
 


### PR DESCRIPTION
Attempt to address the fallout that resulted in moving workshops in the site hierarchy, combined with a previous decision to track the stub of all pages. More details in 0ecc646.