### PR TITLE
Use Font Awesome CDN

### DIFF
--- a/app/views/pages/layouts/default.liquid
+++ b/app/views/pages/layouts/default.liquid
@@ -18,6 +18,8 @@ is_layout: false
       try{Typekit.load({ async: true });}catch(e){}
     </script>
 
+    <link rel="stylesheet" href="https://use.fontawesome.com/82de14177b.css">
+
     {{ 'main.css' | stylesheet_tag }}
     {{ 'vendor.bundle.js' | javascript_tag }}
   </head>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
-    "font-awesome": "^4.6.3",
     "html-loader": "^0.4.3",
     "lodash": "^4.12.0",
     "mathsass": "^0.9.5",

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -3,7 +3,6 @@
 
 @import '~normalize-scss/sass/normalize/import-now';
 @import 'helpers/mixins';
-@import '~font-awesome/scss/font-awesome';
 // Semantic-UI components via css for now since Sass port is not yet a reality
 @import '~semantic-ui-css/components/button.min';
 @import '~semantic-ui-css/components/card.min';


### PR DESCRIPTION
My previous attempt to refactor the Font Awesome font handling in 3c4bbc0 was
too good to be true. Browser cache was spoofing expected functionality when
reality was far from it. I could go back to using copy-webpack-plugin, but that
would put us in the same spot with AppSpider scan #465.

So...keep it simple and go with the CDN until further notice. Should keep
everyone happy in the meantime.