### PR TITLE
Apply stickyheaders after softwareList is created

### DIFF
--- a/vue/software-list/components/software-list.vue
+++ b/vue/software-list/components/software-list.vue
@@ -14,6 +14,11 @@
       this.parseCsv()
     },
 
+    // Ensure stickyheaders are applied after softwareList is populated/generated/created
+    watch: {
+      softwareList: 'stickyHeaders'
+    },
+
     methods: {
       parseCsv () {
         var converter = new Converter()
@@ -26,6 +31,10 @@
            // console.log(jsonObj)
            vm.$set('softwareList', jsonObj)
         });
+      },
+
+      stickyHeaders () {
+        $('.software-list__table').stickySort()
       }
     }
   }

--- a/vue/software-list/software-list.js
+++ b/vue/software-list/software-list.js
@@ -20,7 +20,3 @@ new Vue({
 
 import 'sticky-sort/jquery.stickysort.min.js'
 import 'sticky-sort/stickysort.css'
-
-$(window).load(function(){
-  $('.software-list__table').stickySort()
-});


### PR DESCRIPTION
This is the key to the bug in #606 and the reason why I was not able to reliably
reproduce this is because when hosting the site on wagon, `$(window).load` would
trigger after the Vue component was updated, but in the opposite order when
hosting on engine. We can ensure the proper order by utilizing Vue's watch
method.