### PR TITLE
Sync move of events calendar from back-office

### DIFF
--- a/app/views/pages/.gitignore
+++ b/app/views/pages/.gitignore
@@ -29,7 +29,7 @@
 !help/research-support/research-help/gis-at-mann.liquid
 !hours.liquid
 !index.liquid
-!news-events/events/upcoming.liquid
+!news-events/events/calendar.liquid
 !projects.liquid
 !search.liquid
 !site-feedback.liquid

--- a/app/views/pages/news-events/events/calendar.liquid
+++ b/app/views/pages/news-events/events/calendar.liquid
@@ -1,6 +1,6 @@
 ---
 title: Upcoming Events/Exhibits
-slug: upcoming
+slug: calendar
 handle: events-calendar
 position: 0
 listed: true


### PR DESCRIPTION
Path is now `/news-events/events/calendar`.