### PR TITLE
Use handle for filtering about page via with_scope

### DIFF
--- a/app/views/snippets/footer.liquid
+++ b/app/views/snippets/footer.liquid
@@ -7,7 +7,7 @@
     </p>
 
     {% comment %} About Us subnav with child pages {% endcomment %}
-    {% with_scope slug: 'about' %}{% assign about_page = site.pages.first %}{% endwith_scope %}
+    {% with_scope handle: 'about' %}{% assign about_page = site.pages.first %}{% endwith_scope %}
     <ul class="footer__about-subnav">
       {% for child in about_page.children %}
         <li><a href="{% path_to child %}" title="{{ child.title }}">{{ child.title }}</a></li>


### PR DESCRIPTION
Wagon had no issue with the slug, but Engine required the handle. Better choice
anyway, since the handle is actually unique ;)