### PR TITLE
Explicit styles for social media on news page

### DIFF
--- a/app/views/snippets/dynamic-news.liquid
+++ b/app/views/snippets/dynamic-news.liquid
@@ -47,7 +47,7 @@
 </div>
 
 <ul class="news-latest__social inline">
-  {% include 'social-media-links' %}
+  {% include 'social-media-links' with component: 'news-latest' %}
 </ul>
 
 {% assign tumblr_url = 'http://mannlibrary.tumblr.com/rss' %}

--- a/app/views/snippets/footer.liquid
+++ b/app/views/snippets/footer.liquid
@@ -118,7 +118,7 @@
 
   <div class="footer__bottomline">
     <ul class="footer__social inline">
-      {% include 'social-media-links' %}
+      {% include 'social-media-links' with component: 'footer' %}
     </ul>
 
     <img class="footer__mann-logo" src="{{ 'cul-brand/mann-logo-white@2x.svg' | theme_image_url }}" alt="Mann Library logo">

--- a/app/views/snippets/social-media-links.liquid
+++ b/app/views/snippets/social-media-links.liquid
@@ -1,20 +1,20 @@
 <li>
-  <a class="footer__social-icon" href="http://facebook.com/mannlibrary" target="_blank" title="Albert R. Mann Library on Facebook">
+  <a class="{{ component }}__social-icon" href="http://facebook.com/mannlibrary" target="_blank" title="Albert R. Mann Library on Facebook">
     <i class="fa fa-facebook-square fa-2x"></i>
   </a>
 </li>
 <li>
-  <a class="footer__social-icon" href="http://mannlibrary.tumblr.com" target="_blank" title="Albert R. Mann Library on Tumblr">
+  <a class="{{ component }}__social-icon" href="http://mannlibrary.tumblr.com" target="_blank" title="Albert R. Mann Library on Tumblr">
     <i class="fa fa-tumblr-square fa-2x"></i>
   </a>
 </li>
 <li>
-  <a class="footer__social-icon" href="https://www.instagram.com/mannlibrary" target="_blank" title="Albert R. Mann Library on Instagram">
+  <a class="{{ component }}__social-icon" href="https://www.instagram.com/mannlibrary" target="_blank" title="Albert R. Mann Library on Instagram">
     <i class="fa fa-instagram fa-2x"></i>
   </a>
 </li>
 <li>
-  <a class="footer__social-icon" href="https://www.flickr.com/photos/mann_library" target="_blank" title="Albert R. Mann Library on Flickr">
+  <a class="{{ component }}__social-icon" href="https://www.flickr.com/photos/mann_library" target="_blank" title="Albert R. Mann Library on Flickr">
     <i class="fa fa-flickr fa-2x"></i>
   </a>
 </li>

--- a/src/scss/components/_news.scss
+++ b/src/scss/components/_news.scss
@@ -49,6 +49,10 @@
   }
 }
 
+.news-latest__social-icon {
+  color: color('aluminum');
+}
+
 .news-latest__stories {
   @include susy-breakpoint($tablet, $g-tablet) {
     @include span(5 nest);


### PR DESCRIPTION
Forgot about the recent overhaul to the footer that set the social media icons
to white and missed this while quickly testing after the merge.

Quick followup for #468.