### PR TITLE
Ensure spotlight is linked only if URL exists

### DIFF
--- a/app/views/snippets/spotlights-looper.liquid
+++ b/app/views/snippets/spotlights-looper.liquid
@@ -1,7 +1,7 @@
 {% for spotlight in spotlights %}
   {% capture spotlight_image %}<img src="{{ spotlight.image.url | image_url }}" alt="{{ spotlight.name }}" title="{{ spotlight.caption }}">{% endcapture %}
 
-  {% if spotlight.url %}
+  {% if spotlight.url.size > 0 %}
     <a href="{{ spotlight.url }}">{{ spotlight_image }}</a>
   {% else %}
     {{ spotlight_image }}


### PR DESCRIPTION
Account for engine's bogus truthy/falsy eval once again. #570