### PR TITLE
Drop all editable_text placeholders from layouts

### DIFF
--- a/app/views/pages/layouts/basic-page.liquid.haml
+++ b/app/views/pages/layouts/basic-page.liquid.haml
@@ -10,9 +10,7 @@ is_layout: true
   {% endblock %}
 
 .page-content
-  {% editable_text "page_content", hint: "Keep it short and sweet" %}
-  Page content here
-  {% endeditable_text %}
+  {% editable_text "page_content", hint: "Keep it short and sweet" %}{% endeditable_text %}
 
 {% include 'section-nav' %}
 

--- a/app/views/pages/layouts/primary-landing.liquid
+++ b/app/views/pages/layouts/primary-landing.liquid
@@ -6,9 +6,7 @@ is_layout: false
 
 {% block 'main' %}
   <div class="landing-description">
-    {% editable_text "landing_description", hint: "Keep it short and sweet" %}
-      Brief description here.
-    {% endeditable_text %}
+    {% editable_text "landing_description", hint: "Keep it short and sweet" %}{% endeditable_text %}
   </div>
 
   {% include 'landing' %}

--- a/app/views/pages/layouts/primary.liquid
+++ b/app/views/pages/layouts/primary.liquid
@@ -6,9 +6,7 @@ is_layout: false
 
 {% block 'main' %}
   <div class="landing-description">
-    {% editable_text "landing_description", hint: "Keep it short and sweet" %}
-      Brief description here.
-    {% endeditable_text %}
+    {% editable_text "landing_description", hint: "Keep it short and sweet" %}{% endeditable_text %}
   </div>
 
   {% include 'section-nav' %}

--- a/app/views/pages/layouts/section.liquid
+++ b/app/views/pages/layouts/section.liquid
@@ -11,9 +11,7 @@ is_layout: true
   <img class="section-page__photo ui rounded image" src="{{ selected_photo }}">
 
   <div class="section-page__content">
-    {% editable_text "landing_description", hint: "Keep it short and sweet" %}
-      Brief description here.
-    {% endeditable_text %}
+    {% editable_text "landing_description", hint: "Keep it short and sweet" %}{% endeditable_text %}
 
     <ul class="section-page__list">
       {% for child in page.children %}


### PR DESCRIPTION
Pretty sure there's a bug in Engine/Steam that doesn't allow these to be
overriden with an empty string. #668