### PR TITLE
Temporarily disable caching for Labstats

### DIFF
--- a/app/views/snippets/availnow-computers-setup.liquid
+++ b/app/views/snippets/availnow-computers-setup.liquid
@@ -9,7 +9,7 @@
 {% if mannlib_hours.status_1707 == 'Open' %}
   {% assign labstats_url = 'https://online.labstats.com/api/public/GetPublicApiData/1001' %}
 
-  {% consume mann_desktops from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60 %}
+  {% consume mann_desktops from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id %}
     {% for location in mann_desktops.groups %}
       {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
       {% case location.label %}


### PR DESCRIPTION
Pretty sure the consume tag is tripping up on the presence of the `header_auth`
option, that I introduced in locomotivecms/steam#67, when caching is also
enabled. Working on debugging this, but in the meantime backing out caching so
we have labstats data for the beta site.

This reverts commit 33abd0d47ddfa990b43986379a3c8546dfbdae2a.