### PR TITLE
The return of R25

### DIFF
--- a/src/scss/components/_events.scss
+++ b/src/scss/components/_events.scss
@@ -1,4 +1,8 @@
 .events {
+  @include susy-breakpoint($scape, $g-scape) {
+    margin-top: 0;
+  }
+
   @include susy-breakpoint($tablet, $g-tablet) {
     @include span(5 nest);
 
@@ -9,6 +13,16 @@
   @include susy-breakpoint($lapdesk, $g-lapdesk) {
     @include span(8 nest);
   }
+
+  @include break;
+  @include span(full nest);
+
+  margin-top: 1em;
+}
+
+.events__applied-filter {
+  display: inline-block;
+  margin-bottom: .5em;
 }
 
 .events__per-day {
@@ -18,6 +32,19 @@
 .events__date-heading {
   border-bottom: solid 3px color('light-gray');
   font-size: modular-scale(1);
+}
+
+.events__toggle-courses {
+  @include susy-breakpoint($scape, $g-scape) {
+    margin: .2em 0 0 3em;
+  }
+
+  float: left;
+}
+
+.events__toggle-courses-label {
+  margin-bottom: 0;
+  font-weight: normal;
 }
 
 .event {
@@ -63,6 +90,8 @@
 
     padding-left: 3.5em;
   }
+
+  @include span(full nest);
 }
 
 .events-filters__clear-all {

--- a/src/scss/components/_page-content.scss
+++ b/src/scss/components/_page-content.scss
@@ -21,6 +21,7 @@
   font-size: modular-scale(2);
 
   // body classes to target specific pages
+  .body-calendar &,
   .body-hours & {
     float: left;
     margin-bottom: .2em;

--- a/vue/events/events-page/components/Events.vue
+++ b/vue/events/events-page/components/Events.vue
@@ -3,6 +3,8 @@ import $ from 'jquery'
 var _ = require('lodash')
 var moment = require('moment')
 
+import 'semantic-ui-css/components/checkbox.min.css';
+import 'semantic-ui-css/components/checkbox.min.js';
 import 'semantic-ui-css/components/dimmer.min.js'
 import 'semantic-ui-css/components/dimmer.min.css'
 import 'semantic-ui-css/components/modal.min.js'

--- a/vue/events/events-page/directives/datepicker-directive.js
+++ b/vue/events/events-page/directives/datepicker-directive.js
@@ -10,7 +10,9 @@ Vue.directive('datepicker', {
         vm.localistReservations = vm.libcalReservations = vm.r25Reservations = []
         vm.getCornellEvents('date', date)
         vm.getLibCalEvents('date', date)
-        // vm.getR25Events('date', date)
+        if (vm.r25Status) {
+          vm.getR25Events('date', date)
+        }
         vm.showNoEventsMessage = true
         vm.allEvents = []
         vm.dateSelected = date

--- a/vue/events/events-page/events-page.js
+++ b/vue/events/events-page/events-page.js
@@ -25,3 +25,7 @@ routes[path_to_events_page] = {
 router.map(routes)
 
 router.start(App, 'body')
+
+$('.ui.checkbox')
+  .checkbox()
+;

--- a/vue/events/events-page/templates/events-template.html
+++ b/vue/events/events-page/templates/events-template.html
@@ -1,4 +1,9 @@
 <div class="events-container">
+  <div class="events__toggle-courses ui toggle checkbox">
+    <input type="checkbox" name="events-toggle-courses" value="1" tabindex="0" class="hidden">
+    <label class="events__toggle-courses-label">Include academic courses</label>
+  </div>
+
 	<div v-show="showNoEventsMessage"class="ui segment">
 		<div class="ui active centered inline loader">
 			<div class="ui text loader">Loading</div>
@@ -10,21 +15,21 @@
 		<div class="tab-content">
 
 			<div class="events__applied-filters">
-	      <a v-if="dateSelected" v-on:click="removeSelectedDate()" title="Remove filter">
+	      <a class="events__applied-filter" v-if="dateSelected" v-on:click="removeSelectedDate()" title="Remove filter">
            <button class="mini ui teal right labeled icon button">
             <i class="remove icon"></i>
             DATE: ((dateSelected | momentDate))
           </button>
         </a>
 
-				<a v-if="eventSelected" v-on:click="removeEventTypeFilter()" title="Remove filter">
+				<a class="events__applied-filter" v-if="eventSelected" v-on:click="removeEventTypeFilter()" title="Remove filter">
           <button class="mini ui teal right labeled icon button">
             <i class="remove icon"></i>
             TYPE: ((eventSelected))
           </button>
         </a>
 
-				<a v-if="roomSelected" v-on:click="removeRoomFilter()" title="Remove filter">
+				<a class="events__applied-filter" v-if="roomSelected" v-on:click="removeRoomFilter()" title="Remove filter">
           <button class="mini ui teal right labeled icon button">
             <i class="remove icon"></i>
             LOCATION: ((roomSelected))

--- a/vue/events/events-page/templates/events-template.html
+++ b/vue/events/events-page/templates/events-template.html
@@ -1,6 +1,6 @@
 <div class="events-container">
   <div class="events__toggle-courses ui toggle checkbox">
-    <input type="checkbox" name="events-toggle-courses" value="1" tabindex="0" class="hidden">
+    <input type="checkbox" name="events-toggle-courses" value="1" tabindex="0" class="hidden" v-model="r25Status" v-on:change="toggleAcademicCourses(r25Status)">
     <label class="events__toggle-courses-label">Include academic courses</label>
   </div>
 


### PR DESCRIPTION
We temporarily disabled the R25 feed in #719 because the academic courses were overwhelming the events calendar. Our plan for re-introducing it back into the wild was hinted at in #720, but here it is again in more detail:

* add a toggle at the top of the Events Calendar, which is disabled by default (academic courses are **not rendered**)
* refactor `HomepageEvents.vue` so it ignores R25 data altogether (it should not include R25 as a data source)
* stick with the **Instruction** event type for R25, which we have already curated to **Academic Course**
  * we've agreed that we will not include any additional alternate names for this curated event type to avoid mixing R25 data with any other data source
* if a user selects the **Academic Course** event type filter, this will also automatically set the aforementioned R25 toggle to `true` if not already