### PR TITLE
Contact info cleanup for staff directory

### DIFF
--- a/app/views/snippets/staff-directory-body-grid.liquid
+++ b/app/views/snippets/staff-directory-body-grid.liquid
@@ -8,10 +8,10 @@
       <div class="header">{{ person.last_name }}, {{ person.first_name }}</div>
       <div class="staff-directory__position">{{ person.title }}</div>
       <div class="staff-directory__contact">
-        <a href="https://www.cornell.edu/search/people.cfm?netid={{ person.netid }}" class="left floated">
+        <a class="left floated" href="https://www.cornell.edu/search/people.cfm?netid={{ person.netid }}" title="Contact details for {{ person.first_name }}" target="_blank">
           <i class="envelope icon"></i> {{ person.netid }}
         </a>
-        <a href="https://www.cornell.edu/search/people.cfm?netid={{ person.netid }}" class="right floated">
+        <a class="right floated" href="tel:+1607-25{{ person.phone }}" title="Call {{ person.first_name }}">
           <i class="phone icon"></i> 607-25{{ person.phone }}
         </a>
       </div>

--- a/app/views/snippets/staff-directory-body-table.liquid
+++ b/app/views/snippets/staff-directory-body-table.liquid
@@ -25,7 +25,15 @@
         </a>
       </td>
     {% endunless %}
-    <td class="top aligned">{{ person.netid }}</td>
-    <td class="top aligned">607-25{{ person.phone }}</td>
+    <td class="top aligned">
+      <a href="https://www.cornell.edu/search/people.cfm?netid={{ person.netid }}" title="Contact details for {{ person.first_name }}" target="_blank">
+        <i class="envelope icon"></i> {{ person.netid }}
+      </a>
+    </td>
+    <td class="top aligned">
+      <a href="tel:+1607-25{{ person.phone }}" title="Call {{ person.first_name }}">
+          <i class="phone icon"></i> 607-25{{ person.phone }}
+      </a>
+    </td>
   </tr>
 {% endfor %}


### PR DESCRIPTION
- markup phone numbers with `tel:` URI for href attribute #579 
- consistency across grid and table views
- `target="_blank"` for external links to CU directory #450
