### PR TITLE
Link software list headings to smartmap

### DIFF
--- a/vue/software-list/components/software-list.html
+++ b/vue/software-list/components/software-list.html
@@ -1,7 +1,10 @@
 <table class="software-list__table ui yellow collapsing selectable unstackable definition celled striped table">
   <thead class="full-width">
     <tr>
-      <th v-for="heading in softwareList[0]" class="center aligned">(( $key ))</th>
+      <th v-for="heading in softwareList[0]" class="center aligned">
+        <a v-if="smartmapQuery($key)" href="http://smartmap.mannlib.cornell.edu/location/(( smartmapQuery($key) ))" title="Map it" target="_blank">(( $key ))</a>
+        <span v-else>(( $key ))</span>
+      </th>
     </tr>
   </thead>
   <tbody class="software-list__tbody">

--- a/vue/software-list/components/software-list.vue
+++ b/vue/software-list/components/software-list.vue
@@ -33,6 +33,19 @@
         });
       },
 
+      // Convert software location names to working SmartMap links
+      smartmapQuery (location) {
+        if (location.indexOf('iMacs') !== -1 || location.indexOf('Research') !== -1) {
+          return 'stone computing center'
+        } else if (location.indexOf('PCs') !== -1) {
+          return location.replace('PCs', '').trim().toLowerCase()
+        } else if (location.indexOf('Circ') !== -1) {
+          return 'circulation services'
+        } else {
+          return false
+        }
+      },
+
       stickyHeaders () {
         $('.software-list__table').stickySort()
       }


### PR DESCRIPTION
Except for email kiosks, which are no longer included in the map. #610 