### PR TITLE
Sort event_locations & event_types by name

### DIFF
--- a/app/content_types/event_locations.yml
+++ b/app/content_types/event_locations.yml
@@ -11,7 +11,7 @@ description: Curated event locations
 label_field_name: name
 
 # Valid values: manually, created_at, updated_at, or the slug of any field
-order_by: manually
+order_by: name
 
 # Valid values: asc (ascending) and desc (descending). Set to asc by default.
 # order_direction: asc

--- a/app/content_types/event_types.yml
+++ b/app/content_types/event_types.yml
@@ -11,7 +11,7 @@ description: Curated event types
 label_field_name: name
 
 # Valid values: manually, created_at, updated_at, or the slug of any field
-order_by: manually
+order_by: name
 
 # Valid values: asc (ascending) and desc (descending). Set to asc by default.
 # order_direction: asc


### PR DESCRIPTION
Makes the list easier to scan and manage in the back-office.