### PR TITLE
Hotfix - filter reservable spaces for Engine

### DIFF
--- a/app/views/snippets/content-type-spaces-types.liquid
+++ b/app/views/snippets/content-type-spaces-types.liquid
@@ -48,8 +48,12 @@
   {% comment %} Filter on reservable study spaces {% endcomment %}
   {% with_scope _slug: 'study' %}{% assign study_space_type = contents.spaces_types.first %}{% endwith_scope %}
   {% with_scope spaces_types: study_space_type %}{% assign study_spaces = contents.spaces.all %} {% endwith_scope %}
-  {% with_scope reservation_system.ne: nil, spaces_types: study_space_type %}{% assign reservable_study_spaces = contents.spaces.all %}{% endwith_scope %}
-
+  {% comment %}
+    Ideally would use reservation_system field to filter but Engine chokes because expecting a BSON objectid
+    -- couldn't figure out an operator to use on a relationship field that could simply test for existence of relationship
+    -- https://github.com/locomotivecms/steam/blob/master/lib/locomotive/steam/liquid/tags/with_scope.rb#L19
+  {% endcomment %}
+  {% with_scope reserve_sys_id.gt: 1, spaces_types: study_space_type %}{% assign reservable_study_spaces = contents.spaces.all %}{% endwith_scope %}
 
   <div class="space-finder__study-spaces">
     <h3 id="reservable" class="space-finder__subheading">Reservable</h3>


### PR DESCRIPTION
Addresses a bug introduced in #759.

Ideally, we would use the `reservation_system` field to filter but Engine chokes
because it's expecting a BSON objectid. I couldn't figure out an operator to use
on a relationship field that could simply test for existence of relationship, so
falling back to test for the existence of the `reserve_sys_id` field via the
`gt` operator since it's an integer field.

Awkward, but works no matter whether the site is served by Wagon or Engine.

List of operators for `with_scope` tag:
https://github.com/locomotivecms/steam/blob/master/lib/locomotive/steam/liquid/tags/with_scope.rb#L19