### PR TITLE
Libcal widget works in both views of staff dir

### DIFF
--- a/app/views/snippets/staff-book-consultation.liquid
+++ b/app/views/snippets/staff-book-consultation.liquid
@@ -10,8 +10,8 @@
 
 <script>
   jQuery(function(){
-     jQuery("#mySched{{ libcal_uid }}").LibCalMySched({ iid: 973, uid: {{ libcal_uid }}, gid: 0,  width: 500, height: 450 });
+     jQuery("#mySched{{ libcal_uid }}{% if caller %}--{{ caller }}{% endif %}").LibCalMySched({ iid: 973, uid: {{ libcal_uid }}, gid: 0,  width: 500, height: 450 });
   });
 </script>
 
-<a id="mySched{{ libcal_uid }}" class="staff-directory__book-consultation {% if class %}{{ class }}{% endif %} ui mini button" href="#">Book a Consultation</a>
+<a id="mySched{{ libcal_uid }}{% if caller %}--{{ caller }}{% endif %}" class="staff-directory__book-consultation {% if class %}{{ class }}{% endif %} ui mini button" href="#">Book a Consultation</a>

--- a/app/views/snippets/staff-directory-body-grid.liquid
+++ b/app/views/snippets/staff-directory-body-grid.liquid
@@ -17,7 +17,7 @@
       </div>
 
       {% if person.libcal_uid.size > 0 %}
-        {% include 'staff-book-consultation' with libcal_uid: person.libcal_uid %}
+        {% include 'staff-book-consultation' with libcal_uid: person.libcal_uid, caller: 'grid' %}
       {% endif %}
     </div>
     <div class="extra content">

--- a/app/views/snippets/staff-directory-body-table.liquid
+++ b/app/views/snippets/staff-directory-body-table.liquid
@@ -9,7 +9,7 @@
           <strong>{{ person.last_name }}, {{ person.first_name }}</strong>
           <span class="staff-directory__position">{{ person.title }}</span>
           {% if person.libcal_uid.size > 0 %}
-            {% include 'staff-book-consultation' with libcal_uid: person.libcal_uid %}
+            {% include 'staff-book-consultation' with libcal_uid: person.libcal_uid, caller: 'table' %}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
Turns out this never worked properly on the staff directory due to having the
consultation button for each staff member rendered two times due to the two
views (grid vs table) -- the table is hidden via JS on page load, but the
duplication of IDs caused only the first button in the DOM (the table) to work.

Ensuring unique IDs for the buttons addressed this problem.