### PR TITLE
Smartmap links for spaces #793

### DIFF
--- a/app/content_types/spaces.yml
+++ b/app/content_types/spaces.yml
@@ -65,6 +65,13 @@ fields:
     inverse_of: spaces
     ui_enabled: true
 
+- smartmap_url: # The lowercase, underscored name of the field
+    label: SmartMap URL # Human readable name of the field
+    type: string
+    required: false
+    hint: Used to link to the Mann SmartMap to aid in patrons finding the location (floor is used as link text)
+    localized: false
+
 - spaces_study_types:
     label: Types of study spaces
     hint: If this is a study space, specify whether indiv, group, quiet

--- a/app/views/snippets/content-type-spaces.liquid
+++ b/app/views/snippets/content-type-spaces.liquid
@@ -55,15 +55,25 @@
   {% endif %}
 
   <dl class="space__rundown">
-    {% if space.room %}
+    {% if space.room.size > 0 %}
       <dt class="space__field-name">Room</dt>
       <dd>{{ space.room }}</dd>
     {% endif %}
 
     {% if space.floor %}
       <dt class="space__field-name">Floor</dt>
-      <dd>{{ space.floor._label }}</dd>
+      <dd>
+        {% if space.smartmap_url.size > 0 %}
+          <a href="{{ space.smartmap_url }}" title="Map it" target="_blank">
+            <i class="fa fa-map-marker"></i>
+            {{ space.floor._label }}
+          </a>
+        {% else %}
+          {{ space.floor._label }}
+        {% endif %}
+      </dd>
     {% endif %}
+
 
     {% if space.spaces_types %}
       <dt class="space__field-name">Type</dt>

--- a/app/views/snippets/spaces-cards.liquid
+++ b/app/views/snippets/spaces-cards.liquid
@@ -22,33 +22,43 @@
         <h3 class="space-finder__name">{{ space.name }}</h3>
 
         <div class="meta space-finder__card-meta">
-          <span class="right floated">
-            {% if spaces_type._slug == 'study' %}
-              {% if quiet_study %}
-                <span class="space-finder__quiet" data-tooltip="quiet study" data-position="left center" data-inverted="">
-                  <span class="fa-stack">
-                    <i class="fa fa-volume-up fa-stack-1x"></i>
-                    <i class="space-finder__quiet-ban fa fa-ban fa-stack-2x"></i>
-                  </span>
+          {% if space_status %}
+              <a class="js-spacefinder-link" href="{% path_to hours %}" title="View all hours">
+                <span class="badge {% if space_status == 'Open' %}badge-success{% else %}badge-error{% endif %}">{{ space_status }}
+                {% if space_hours %}
+                  {% if space_hours == '24 hours' %}
+                    {{ space_hours }}
+                  {% else %}
+                    {{ space_hours | prepend: 'until '}}
+                  {% endif %}
+                {% endif %}
                 </span>
-              {% endif %}
-            {% elsif spaces_type._slug == 'classroom' or spaces_type._slug == 'computing-facilities' %}
-              {% comment %} Need logic here to first see if room is available (all but stone computing center) {% endcomment %}
-              {% comment %} <i class="fa fa-desktop"></i> 27 {% endcomment %}
+              </a>
+          {% endif %}
+
+          <span class="right floated">
+            {% if space.smartmap_url.size > 0 %}
+              <a class="js-spacefinder-link right floated" href="{{ space.smartmap_url }}" title="Map it" target="_blank">
+                <i class="fa fa-map-marker"></i>
+                {{ space.floor._label }}
+              </a>
+            {% else %}
+              {{ space.floor._label }}
             {% endif %}
           </span>
-          {% if space_status %}
-            <a class="js-spacefinder-link" href="{% path_to hours %}" title="View all hours">
-              <span class="badge {% if space_status == 'Open' %}badge-success{% else %}badge-error{% endif %}">{{ space_status }}
-              {% if space_hours %}
-                {% if space_hours == '24 hours' %}
-                  {{ space_hours }}
-                {% else %}
-                  {{ space_hours | prepend: 'until '}}
-                {% endif %}
-              {% endif %}
+
+          {% if spaces_type._slug == 'study' %}
+            {% if quiet_study %}
+              <span class="space-finder__quiet" data-tooltip="quiet study" data-position="bottom left" data-inverted="">
+                <span class="fa-stack">
+                  <i class="fa fa-volume-up fa-stack-1x"></i>
+                  <i class="space-finder__quiet-ban fa fa-ban fa-stack-2x"></i>
+                </span>
               </span>
-            </a>
+            {% endif %}
+          {% elsif spaces_type._slug == 'classroom' or spaces_type._slug == 'computing-facilities' %}
+            {% comment %} Need logic here to first see if room is available (all but stone computing center) {% endcomment %}
+            {% comment %} <i class="fa fa-desktop"></i> 27 {% endcomment %}
           {% endif %}
         </div>
 

--- a/src/scss/components/_space-finder.scss
+++ b/src/scss/components/_space-finder.scss
@@ -58,7 +58,7 @@
 
 .space-finder__quiet {
   display: block;
-  padding-left: .25em;
+  margin-top: .25em;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
- new `smartmap_url` field for spaces content_type
- if it's populated, floor will render as link with map marker
- otherwise the floor will render sans link
