### PR TITLE
Use site.name instead of site.seo-title for header

### DIFF
--- a/app/views/snippets/header.liquid
+++ b/app/views/snippets/header.liquid
@@ -13,7 +13,7 @@
     </h2>
 
     <h1 class="mann-brand__mannlib">
-      <a class="link--no-color" href="/" title="Home">{{ site.seo_title | upcase }}</a>
+      <a class="link--no-color" href="/" title="Home">{{ site.name | upcase }}</a>
     </h1>
   </div>
 

--- a/config/site.yml
+++ b/config/site.yml
@@ -1,7 +1,7 @@
 # The name of this site
 # This text displays in the back-office and
 # can be used in templates through the site.name global variable
-name: "mann-library"
+name: "Mann Library"
 
 # An array of domain aliases for the site
 # This option is for sites on multi-site engines


### PR DESCRIPTION
This is necessary after SEO changes introduced in #807. Without it, our logo
would read **Albert R. Mann Library**

<img width="718" alt="screenshot 2016-11-01 14 15 01" src="https://cloud.githubusercontent.com/assets/409842/19901628/19dfbabc-a03e-11e6-9b3f-7b15e797f253.png">
