### PR TITLE
Temp punt on desktop availability via Labstats

### DIFF
--- a/app/views/snippets/accessory-desktops.liquid
+++ b/app/views/snippets/accessory-desktops.liquid
@@ -12,52 +12,8 @@
 
   {% assign labstats_url = 'https://online.labstats.com/api/public/GetPublicApiData/1001' %}
 
-  {% consume mann_desktops from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60 %}
-    {% for location in mann_desktops.groups %}
-      {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
-      {% case location.label %}
-        {% when 'B30A' %}
-          {% assign b30a = location %}
-        {% when 'B30B' %}
-          {% assign b30b = location %}
-        {% when 'CIT 101' %}
-          {% assign cit_101 = location %}
-        {% when 'CIT 112' %}
-          {% assign cit_112 = location %}
-        {% when 'CIT Mac 220A' %}
-          {% assign cit_mac_220a = location %}
-        {% when 'McManus' %}
-          {% assign mcmanus = location %}
-        {% when 'Research' %}
-          {% assign research_win = location %}
-        {% when 'Research Mac' %}
-          {% assign research_mac = location %}
-        {% when 'Stone' %}
-          {% assign stone = location %}
-      {% endcase %}
-    {% endfor %}
-
-  {% assign windows_avail = cit_101.available | plus: cit_112.available | plus: research_win.available | plus: stone.available %}
-
-  {% comment %} Include B30 classrooms in total count if basement is open {% endcomment %}
-  {% if mannlib_hours.status_2319 == 'Open' %}
-    {% assign windows_avail = windows_avail | plus: b30a.available | plus: b30b.available %}
-
-    {% assign basement_status = false %}
-  {% else %}
-    {% assign b30a = nil %}
-    {% assign b30b = nil %}
-
-    {% capture basement_status %}<a href="{% path_to hours %}" title="View all hours"><span class="badge badge-error">Closed</span></a>{% endcapture %}
-  {% endif %}
-
-  {% assign macs_avail = cit_mac_220a.available | plus: mcmanus.available | plus: research_mac.available %}
-
-  {% assign stone_center_win =  cit_101.available | plus: research_win.available %}
-
   {% include 'availnow-desktops-template' %}
 
-  {% endconsume %}
 {% else %}
   {% capture computer_accessory_heading %}<a href="{% path_to hours %}" title="View all hours"><span class="badge badge-error">Closed</span></a> <a class="todays-hours__more" href="{% path_to hours %}" title="View all hours">All Hours <i class="fa fa-angle-double-right"></i></a>{% endcapture %}
   {% include 'availnow-desktops-template' %}

--- a/app/views/snippets/availnow-computers.liquid
+++ b/app/views/snippets/availnow-computers.liquid
@@ -19,52 +19,8 @@
 
   {% assign labstats_url = 'https://online.labstats.com/api/public/GetPublicApiData/1001' %}
 
-  {% consume mann_computers from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60 %}
-    {% for location in mann_computers.groups %}
-      {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
-      {% case location.label %}
-        {% when 'B30A' %}
-          {% assign b30a = location %}
-        {% when 'B30B' %}
-          {% assign b30b = location %}
-        {% when 'CIT 101' %}
-          {% assign cit_101 = location %}
-        {% when 'CIT 112' %}
-          {% assign cit_112 = location %}
-        {% when 'CIT Mac 220A' %}
-          {% assign cit_mac_220a = location %}
-        {% when 'McManus' %}
-          {% assign mcmanus = location %}
-        {% when 'Research' %}
-          {% assign research_win = location %}
-        {% when 'Research Mac' %}
-          {% assign research_mac = location %}
-        {% when 'Stone' %}
-          {% assign stone = location %}
-      {% endcase %}
-    {% endfor %}
-
-  {% assign windows_avail = cit_101.available | plus: cit_112.available | plus: research_win.available | plus: stone.available %}
-
-  {% comment %} Include B30 classrooms in total count if basement is open {% endcomment %}
-  {% if mannlib_hours.status_2319 == 'Open' %}
-    {% assign windows_avail = windows_avail | plus: b30a.available | plus: b30b.available %}
-
-    {% assign basement_status = false %}
-  {% else %}
-    {% assign b30a = nil %}
-    {% assign b30b = nil %}
-
-    {% capture basement_status %}<a href="{% path_to hours %}" title="View all hours"><span class="badge badge-error">Closed</span></a>{% endcapture %}
-  {% endif %}
-
-  {% assign macs_avail = cit_mac_220a.available | plus: mcmanus.available | plus: research_mac.available %}
-
-  {% assign stone_center_win =  cit_101.available | plus: research_win.available %}
-
   {% include 'availnow-computers-template' %}
 
-  {% endconsume %}
 {% else %}
   {% capture computer_accessory_heading %}<a href="{% path_to hours %}" title="View all hours"><span class="badge badge-error">Closed</span></a> <a class="todays-hours__more" href="{% path_to hours %}" title="View all hours">All Hours <i class="fa fa-angle-double-right"></i></a>{% endcapture %}
   {% include 'availnow-computers-template' %}


### PR DESCRIPTION
Labstats API went down and/or was unresponsive and/or there were issues with
certain nameservers (dnsexit.com?) properly resolving online.labstats.com. See
Alan for more details.

This is a quick fix and we should probably update to latest Engine & Steam RCs
so we can reap the benefit of the recent enhancment to the `consume` tag:

locomotivecms/steam@e0b85a3