### PR TITLE
Set timeout of 5 seconds on consume tag

### DIFF
--- a/app/views/snippets/accessory-desktops.liquid
+++ b/app/views/snippets/accessory-desktops.liquid
@@ -12,7 +12,7 @@
 
   {% assign labstats_url = 'https://online.labstats.com/api/public/GetPublicApiData/1001' %}
 
-  {% consume mann_desktops from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60 %}
+  {% consume mann_desktops from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60, timeout: 5.0  %}
     {% for location in mann_desktops.groups %}
       {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
       {% case location.label %}

--- a/app/views/snippets/accessory-laptops.liquid
+++ b/app/views/snippets/accessory-laptops.liquid
@@ -12,7 +12,7 @@
 
   {% assign laptops_url = 'http://mannservices.mannlib.cornell.edu/LibServices/showLaptopInfo.do?output=json&locationId=14' %}
 
-  {% consume mann_laptops from laptops_url %}
+  {% consume mann_laptops from laptops_url, timeout: 5.0  %}
     {% assign winbook_avail = mann_laptops.laptop_available | ceil %}
     {% assign macbook_avail = mann_laptops.macbook_available | ceil %}
 

--- a/app/views/snippets/availnow-computers.liquid
+++ b/app/views/snippets/availnow-computers.liquid
@@ -12,14 +12,14 @@
 
   {% assign laptops_url = 'http://mannservices.mannlib.cornell.edu/LibServices/showLaptopInfo.do?output=json&locationId=14' %}
 
-  {% consume mann_laptops from laptops_url %}
+  {% consume mann_laptops from laptops_url, timeout: 5.0  %}
     {% assign winbook_avail = mann_laptops.laptop_available | ceil %}
     {% assign macbook_avail = mann_laptops.macbook_available | ceil %}
   {% endconsume %}
 
   {% assign labstats_url = 'https://online.labstats.com/api/public/GetPublicApiData/1001' %}
 
-  {% consume mann_computers from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60 %}
+  {% consume mann_computers from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60, timeout: 5.0 %}
     {% for location in mann_computers.groups %}
       {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
       {% case location.label %}

--- a/app/views/snippets/daily-haiku.liquid
+++ b/app/views/snippets/daily-haiku.liquid
@@ -1,7 +1,7 @@
 {% assign haiku_feed = 'http://feeds.feedburner.com/mannlibrary/dailyhaiku' %}
 
 {% comment %} Cache for 6 hrs {% endcomment %}
-{% consume mann_haiku from haiku_feed, expires_in: 21600 %}
+{% consume mann_haiku from haiku_feed, expires_in: 21600, timeout: 5.0  %}
   {% if mann_haiku %}
     {% comment %} Strip Feeburner img appended to encoded description {% endcomment %}
     {% assign latest_haiku = mann_haiku.rss.channel.item.first.encoded | split: '</p>' | first | append: '</p>' %}

--- a/app/views/snippets/dynamic-course-reserves.liquid
+++ b/app/views/snippets/dynamic-course-reserves.liquid
@@ -2,7 +2,7 @@
 {% assign course_reserves_url = 'http://mannservices.mannlib.cornell.edu/LibServices/showCourseReserveList.do?library=MANN&output=json' %}
 
 <div class="course-reserves">
-  {% consume mann_reserves from course_reserves_url, expires_in: 3600 %}
+  {% consume mann_reserves from course_reserves_url, expires_in: 3600, timeout: 5.0  %}
     {% comment %}{{ mann_reserves.course_list }}{% endcomment %}
 
     {% assign sorted_courses = mann_reserves.course_list | sort: 'display_course_number' %}

--- a/app/views/snippets/dynamic-news.liquid
+++ b/app/views/snippets/dynamic-news.liquid
@@ -51,7 +51,7 @@
 
 {% assign tumblr_url = 'http://mannlibrary.tumblr.com/rss' %}
 
-{% consume mann_tumblr from tumblr_url, expires_in: 3600 %}
+{% consume mann_tumblr from tumblr_url, expires_in: 3600, timeout: 5.0  %}
   {% if mann_tumblr %}
     {% assign latest_post = mann_tumblr.rss.channel.item.first %}
 

--- a/app/views/snippets/dynamic-software-list.liquid
+++ b/app/views/snippets/dynamic-software-list.liquid
@@ -2,7 +2,7 @@
 {% assign softwarelist_url = 'https://raw.githubusercontent.com/cul-it/mann-softwarelist-csv/master/softwarelist.csv' %}
 
 <div class="software-list">
-  {% consume mann_software from softwarelist_url, expires_in: 3600 %}
+  {% consume mann_software from softwarelist_url, expires_in: 3600, timeout: 5.0  %}
 
     {% comment %}
       You won't believe the nonsense involved to get the multiline string ready to pass to JS

--- a/app/views/snippets/equipment-list-setup.liquid
+++ b/app/views/snippets/equipment-list-setup.liquid
@@ -1,6 +1,6 @@
 {% assign equipment_url = 'http://mannservices.mannlib.cornell.edu/LibServices/showEquipmentInfo.do?locationId=14&output=json' %}
 
-{% consume mann_equipment from equipment_url %}
+{% consume mann_equipment from equipment_url, timeout: 5.0  %}
 
   {% for equipment in mann_equipment.equipment_list %}
     {% if equipment.equipment_type == 'digital-video-camera-0' or equipment.equipment_type == 'digital-camera-0' %}
@@ -27,5 +27,5 @@
     {% else %}
     {% endif %}
   {% endfor %}
-  
+
 {% endconsume %}

--- a/app/views/snippets/equipment-type-setup.liquid
+++ b/app/views/snippets/equipment-type-setup.liquid
@@ -1,6 +1,6 @@
 {% assign equipment_url = 'http://mannservices.mannlib.cornell.edu/LibServices/showEquipmentInfo.do?locationId=14&output=json' %}
 
-{% consume mann_equipment from equipment_url %}
+{% consume mann_equipment from equipment_url, timeout: 5.0  %}
 
   {% for equipment in mann_equipment.equipment_list %}
     {% comment %}Camera types{% endcomment %}

--- a/app/views/snippets/room-availability-logic.liquid
+++ b/app/views/snippets/room-availability-logic.liquid
@@ -11,7 +11,7 @@
     {% assign room_param = "&room_id=" | append: room_id %}
     {% assign api_request_url = api_request_url | append: room_param%}
 
-    {% consume libcal_api from api_request_url %}
+    {% consume libcal_api from api_request_url, timeout: 5.0  %}
       {% assign libcal_timeslots = libcal_api.availability.timeslots %}
       {% for timeslot in libcal_timeslots %}
         {% comment %} Now available {% endcomment %}

--- a/app/views/snippets/room-availability-variables.liquid
+++ b/app/views/snippets/room-availability-variables.liquid
@@ -1,7 +1,7 @@
 {% assign current_time = now | date: '%s' %}
 
 {% comment %}MannServices Room Availability{% endcomment %}
-{% consume mannservices_api from "http://mannservices.mannlib.cornell.edu/LibServices/showRoomInfo.do?output=json&locationId=14" %}
+{% consume mannservices_api from "http://mannservices.mannlib.cornell.edu/LibServices/showRoomInfo.do?output=json&locationId=14", timeout: 5.0  %}
   {% assign grad_room_now_available = mannservices_api.grad_room_available %}
   {% for grad_rooms in mannservices_api.grad_room_list | json %}
     {% for due_dates in grad_rooms.due_date %}


### PR DESCRIPTION
Use timeout of 5 seconds for slow/unresponsive services, will update to latest steam rc in another PR.