### PR TITLE
Fix select-options for spaces & software requests

### DIFF
--- a/app/content_types/software_requests.yml
+++ b/app/content_types/software_requests.yml
@@ -132,7 +132,7 @@ fields:
     localized: false    # if localized, use
     #   en: ['option1_en', 'option2_en']
     #   fr: ['option1_fr', 'option2_fr']
-    select_options: ['Hand deliver to Mann Library ITS - Attention: Gabriel Plaine', 'Will email license/software/instructions to mann-pac-l@cornell.edu', 'Software can be downloaded at website provided above', 'See Notes below']
+    select_options: ['Hand deliver to Mann Library ITS - Attention: Gabriel Plaine', 'Will email license/software/instructions to mann-pac-help@cornell.edu', 'Software can be downloaded at website provided above', 'See Notes below']
 
 - location: # The lowercase, underscored name of the field
     label: Location # Human readable name of the field

--- a/app/content_types/spaces.yml
+++ b/app/content_types/spaces.yml
@@ -110,7 +110,7 @@ fields:
     localized: false    # if localized, use
     #   en: ['option1_en', 'option2_en']
     #   fr: ['option1_fr', 'option2_fr']
-    select_options: ['N/A', '1', '6', '8', '17', '22', '26', '27', '31', '44', '50']
+    select_options: ['N/A', '1', '4', '7', '17', '22', '26', '27', '31', '44', '50']
 
 - features: # The lowercase, underscored name of the field
     label: Features # Human readable name of the field


### PR DESCRIPTION
The options have been edited in the back-office and is causing errors
when attempting to sync via Wagon and then deploy the site to another
Engine.

Issue submitted asking clarification on whether this is the expected
behavior. locomotivecms/engine#1206