### PR TITLE
Lazy load spotlight & expert carousels #835 #836

### DIFF
--- a/app/views/snippets/meet-experts.liquid
+++ b/app/views/snippets/meet-experts.liquid
@@ -14,7 +14,7 @@
 
           {% assign placeholder_image = 'placeholder.jpg' | theme_image_url %}
           <a href="{{ profile_url }}" title="Contact details">
-            <img class="meet-experts__photo {% unless person.photo.url %}meet-experts__photo--placeholder{% endunless %}" src="{{ person.photo.url | resize: '500x500#n' | default: placeholder_image }}">
+            <img class="meet-experts__photo {% unless person.photo.url %}meet-experts__photo--placeholder{% endunless %}" data-lazy="{{ person.photo.url | resize: '500x500#n' | default: placeholder_image }}">
           </a>
 
           <h5 class="meet-experts__name"><a href="{{ profile_url }}" title="Contact details">{{ person.first_name }} {{ person.last_name }}</a></h5>

--- a/app/views/snippets/spotlights-looper.liquid
+++ b/app/views/snippets/spotlights-looper.liquid
@@ -1,5 +1,5 @@
 {% for spotlight in spotlights %}
-  {% capture spotlight_image %}<img src="{{ spotlight.image.url | image_url }}" alt="{{ spotlight.name }}" title="{{ spotlight.caption }}">{% endcapture %}
+  {% capture spotlight_image %}<img data-lazy="{{ spotlight.image.url | image_url }}" alt="{{ spotlight.name }}" title="{{ spotlight.caption }}">{% endcapture %}
 
   {% if spotlight.url.size > 0 %}
     <a href="{{ spotlight.url }}">{{ spotlight_image }}</a>


### PR DESCRIPTION
No need to resort to Vue since Slick supports lazy loading out of the
box. Initial testing revealed a 47% decrease in homepage loading time
when hosting the site on Engine.

Next up is to optimize the heck out of the images.