### PR TITLE
Functional contact links for meet our experts

### DIFF
--- a/app/views/snippets/dynamic-all-experts.liquid
+++ b/app/views/snippets/dynamic-all-experts.liquid
@@ -46,16 +46,16 @@
             {% endif %}
           </div>
 
-          <div class="all-experts__contact">
-            <a class="all-experts__email" href="https://www.cornell.edu/search/people.cfm?netid={{ person.netid }}" title="Contact details for {{ person.first_name }}" target="_blank">
-              <i class="fa fa-fw fa-envelope"></i> {{ person.netid }}
-            </a>
-            <a href="tel:+1607-25{{ person.phone }}" title="Call {{ person.first_name }}">
-              <i class="fa fa-fw fa-phone"></i> 607-25{{ person.phone }}
-            </a>
-          </div>
-
           <div class="all-experts__body">
+            <div class="all-experts__contact">
+              <a class="all-experts__email" href="https://www.cornell.edu/search/people.cfm?netid={{ person.netid }}" title="Contact details for {{ person.first_name }}" target="_blank">
+                <i class="fa fa-fw fa-envelope"></i> {{ person.netid }}
+              </a>
+              <a href="tel:+1607-25{{ person.phone }}" title="Call {{ person.first_name }}">
+                <i class="fa fa-fw fa-phone"></i> 607-25{{ person.phone }}
+              </a>
+            </div>
+
             <h3 class="all-experts__name">{{ person.first_name }} {{ person.last_name }}</h3>
             <span class="all-experts__title">{{ person.title }}</span>
 

--- a/src/scss/components/all-experts.scss
+++ b/src/scss/components/all-experts.scss
@@ -6,17 +6,11 @@
 }
 
 .all-experts__body {
-  @include susy-breakpoint($scape, $g-scape) {
-    margin-top: 0;
-  }
-
   @include susy-breakpoint($tablet, $g-tablet) {
     @include span(isolate 6 at 3);
   }
 
   @include span(isolate 3 at 2);
-
-  margin-top: 1em;
 }
 
 .all-experts__photo-consult {
@@ -37,13 +31,11 @@
 }
 
 .all-experts__contact {
-  @include susy-breakpoint($scape, $g-scape) {
-    @include span(isolate 2 at 5);
+  @include susy-breakpoint($tablet, $g-tablet) {
+    @include span(isolate 5 at 4);
 
     text-align: right;
   }
-
-  @include span(isolate 3 at 2);
 
   font-size: modular-scale(-1);
 }


### PR DESCRIPTION
Susy's isolate tricked me into thinking the layout was good but in
reality `.all-experts__contact` was buried beneath `.all-experts__body`.
It was all good on mobile devices but busted on bigger breakpoints.
That's what I get for last-minute implementation without fully testing.