### PR TITLE
Disable LiveReload when serving site via wagon

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vue-router": "^0.7.13"
   },
   "scripts": {
-    "start": "bundle exec wagon serve -v -d -f && webpack --progress --watch"
+    "start": "bundle exec wagon serve -v -l=0 -d -f && webpack --progress --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hat tip to jiansong who shared his workaround via Gitter:
https://gitter.im/locomotivecms/wagon?at=58fdf4ca8bb56c2d11d9be5c

I added a comment asking Didier to confirm whether this is the expected
behavior since documentation details steps to enable LiveReload,
inferring that it is disabled by default, not vice versa.
https://gitter.im/locomotivecms/wagon?at=58fe1ebc6aea30763d39cc09