### PR TITLE
Switch to Sara for hand delivery option on software requests

### DIFF
--- a/app/content_types/software_requests.yml
+++ b/app/content_types/software_requests.yml
@@ -132,7 +132,7 @@ fields:
     localized: false    # if localized, use
     #   en: ['option1_en', 'option2_en']
     #   fr: ['option1_fr', 'option2_fr']
-    select_options: ['Hand deliver to Mann Library ITS - Attention: Gabriel Plaine', 'Will email license/software/instructions to mann-pac-help@cornell.edu', 'Software can be downloaded at website provided above', 'See Notes below']
+    select_options: ['Hand deliver to Mann Library ITS - Attention: Sara E. Wright', 'Will email license/software/instructions to mann-pac-help@cornell.edu', 'Software can be downloaded at website provided above', 'See Notes below']
 
 - location: # The lowercase, underscored name of the field
     label: Location # Human readable name of the field


### PR DESCRIPTION
Now that Gabriel has started his new position with A&S on June 30th.

I made this change to the options in the back office last week, but this
is one of those examples that don't sync well between Mongo (Engine) and
filesystem (Wagon).