### PR TITLE
Hint for staff photo placeholder

### DIFF
--- a/app/content_types/staff.yml
+++ b/app/content_types/staff.yml
@@ -86,6 +86,7 @@ fields:
     label: Photo # Human readable name of the field
     type: file
     required: false
+    hint: A placeholder photo will be used if no photo is selected
     localized: false
 
 - birthday: # The lowercase, underscored name of the field


### PR DESCRIPTION
Make it clear(er) that the photo is optional and the placeholder will
automatically be used if necessary. More details in #863.