### PR TITLE
Image caption field for news content_type

### DIFF
--- a/app/content_types/news.yml
+++ b/app/content_types/news.yml
@@ -74,6 +74,7 @@ fields:
     label: Image # Human readable name of the field
     type: file
     required: false
+    hint: Width should be 400px minimum
     localized: false
 
 - image_align: # The lowercase, underscored name of the field
@@ -85,6 +86,13 @@ fields:
     #   en: ['option1_en', 'option2_en']
     #   fr: ['option1_fr', 'option2_fr']
     select_options: ['left', 'right']
+
+- image_caption: # The lowercase, underscored name of the field
+    label: Image Caption # Human readable name of the field
+    type: string
+    required: false
+    hint: Optional! Can be used for photo credit
+    localized: false
 
 # nac26, 2016-10-13: Disable this feature for initial launch & revisit later
 # - featured: # The lowercase, underscored name of the field

--- a/app/views/snippets/content-type-news.liquid
+++ b/app/views/snippets/content-type-news.liquid
@@ -3,7 +3,13 @@
     {{ news.date | date: '%a %b %e, %Y' }}
   </strong>
 
-  <img class="news-story__image ui rounded floated {{ news.image_align }} image" src="{{ news.image.url | resize: '400x>' }}">
+  <figure class="news-story__image {{ news.image_align }}">
+    <img class="ui rounded image" src="{{ news.image.url | resize: '400x>' }}">
+
+    {% if news.image_caption %}
+      <figcaption class="news-story__image-caption">{{ news.image_caption }}</figcaption>
+    {% endif %}
+  </figure>
 
   {{ news.body }}
 </div>

--- a/src/scss/components/_news.scss
+++ b/src/scss/components/_news.scss
@@ -75,7 +75,23 @@
 }
 
 .news-story__image {
-  @include susy-breakpoint($scape $lapdesk, $g-scape) {
+  @include susy-breakpoint($scape $allout, $g-scape) {
     width: span(3);
   }
+
+  float: left;
+  margin: 0 1em 1em 0;
+  max-width: 400px;
+
+  &.right {
+    float: right;
+    margin: 0 0 1em 1em;
+  }
+}
+
+.news-story__image-caption {
+  margin-top: .2em;
+  line-height: 1.2em;
+  color: color('medium-gray');
+  font-style: italic;
 }


### PR DESCRIPTION
As requested per cul-it/mann-sitefeedback#30. Also includes a hint for
the image field to use an image with minimum width of 400px.