### PR TITLE
Bugfix: Wrap unlinked spotlight img in <span> #902

### DIFF
--- a/app/views/snippets/spotlights-looper.liquid
+++ b/app/views/snippets/spotlights-looper.liquid
@@ -1,10 +1,10 @@
 {% for spotlight in spotlights %}
-  {% capture spotlight_image %}<img data-lazy="{{ spotlight.image.url | image_url }}" alt="{{ spotlight.name }}" title="{{ spotlight.caption }}">{% endcapture %}
+  {% capture spotlight_image %}<img data-lazy="{{ spotlight.image.url }}" alt="{{ spotlight.name }}" title="{{ spotlight.caption }}">{% endcapture %}
 
   {% if spotlight.url.size > 0 %}
     <a href="{{ spotlight.url }}">{{ spotlight_image }}</a>
   {% else %}
-    {{ spotlight_image }}
+    <span>{{ spotlight_image }}</span>
   {% endif %}
 
   {% assign counter = counter | plus: 1 %}


### PR DESCRIPTION
This bug was original introduced when switching to lazy-load way back in
1eb881b as part of #846. Turns out Slick's `data-lazy` attribute
requires the image to be wrapped so it's not a direct child of the
element that's targeted for the carousel. This explains why linked
spotlights were rendering properly (wrapped within an anchor <a>).

Also drops non-existent `image_url` liquid filter which appears to have
been hanging around since spotlights were first implemented.

P.S. This addresses the dupe cul-it/mann-sitefeedback#53.