### PR TITLE
Upgrade to Slick Carousel v1.7.1 #464 #885

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "list.js": "^1.2.0",
     "semantic-ui-calendar": "0.0.3",
     "semantic-ui-css": "^2.2.1",
-    "slick-carousel": "github:kenwheeler/slick#1.7.0",
+    "slick-carousel": "^1.7.1",
     "vue": "^1.0.23",
     "vue-filter": "^0.1.1",
     "vue-resource": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4648,15 +4648,9 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-slick-carousel@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.6.0.tgz#780f378e470f4e6f6bec1aa2bae0475f4f9eb085"
-  dependencies:
-    jquery ">=1.7.2"
-
-"slick-carousel@github:kenwheeler/slick#1.7.0":
-  version "1.7.0"
-  resolved "https://codeload.github.com/kenwheeler/slick/tar.gz/bee9b59866d5fe09abb6d7358ea9d5d2d53054fd"
+slick-carousel@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.7.1.tgz#51f5489bbb52212542ccbe9f42689f818bd29ed2"
   dependencies:
     jquery ">=1.7.2"
 


### PR DESCRIPTION
Addresses the WCAG Level A error that persisted from #883 re:
aria-pressed state.