### PR TITLE
Libservices SSL for client-side requests

### DIFF
--- a/app/views/snippets/daily-haiku.liquid
+++ b/app/views/snippets/daily-haiku.liquid
@@ -1,4 +1,4 @@
-{% assign haiku_feed = 'http://feeds.feedburner.com/mannlibrary/dailyhaiku' %}
+{% assign haiku_feed = 'https://feeds.feedburner.com/mannlibrary/dailyhaiku' %}
 
 {% comment %} Cache for 6 hrs {% endcomment %}
 {% consume mann_haiku from haiku_feed, expires_in: 21600, timeout: 5.0  %}

--- a/data/reservation_systems.yml
+++ b/data/reservation_systems.yml
@@ -1,5 +1,5 @@
 - LibCal:
     _slug: libcal
     name: LibCal
-    url: http://spaces.library.cornell.edu
+    url: https://spaces.library.cornell.edu
     api_url: https://api3.libcal.com

--- a/data/spaces.yml
+++ b/data/spaces.yml
@@ -51,7 +51,7 @@
     description: "<p>Study rooms for graduate students.</p>"
     capacity: '1'
     loan_period: 8-hour
-    avail_url: http://mannservices.mannlib.cornell.edu/LibServices/showRoomInfo.do?output=json&locationId=14
+    avail_url: https://mannservices.mannlib.cornell.edu/LibServices/showRoomInfo.do?output=json&locationId=14
 - Hive:
     _slug: hive
     name: Hive

--- a/vue/course-reserves/course-reserves.js
+++ b/vue/course-reserves/course-reserves.js
@@ -38,7 +38,7 @@ var vm = new Vue({
   methods: {
     getReserveItems () {
       if (this.selectedCourse) {
-        var reservesApiBaseUrl = 'http://mannservices.mannlib.cornell.edu/LibServices/showCourseReserveItemInfo.do?output=json&courseid='
+        var reservesApiBaseUrl = 'https://mannservices.mannlib.cornell.edu/LibServices/showCourseReserveItemInfo.do?output=json&courseid='
         var reservesApiUrl = reservesApiBaseUrl + this.selectedCourse
 
         this.toggleLoader()


### PR DESCRIPTION
An extension of #779. In response to patron feedback in cul-it/mann-sitefeedback#57.

Would have liked to use SSL for server-side requests to Libservices as well, but currently stymied by SSL cert failure. More details in [DLITSYS-2579 (Jira)](https://culibrary.atlassian.net/browse/DLITSYS-2579).

> Also updated all other non SSL server side requests via `consume` tag