### PR TITLE
Bump to latest stable jquery-ui v1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "csvtojson": "^1.0.2",
     "formvalidation": "github:formvalidation/formvalidation",
     "jquery": "^2.2.4",
-    "jquery-ui": "1.10.5",
+    "jquery-ui": "1.12.1",
     "list.js": "^1.2.0",
     "semantic-ui-calendar": "0.0.3",
     "semantic-ui-css": "^2.2.1",

--- a/vue/events/events-page/directives/datepicker-directive.js
+++ b/vue/events/events-page/directives/datepicker-directive.js
@@ -1,5 +1,5 @@
 var Vue = require('vue')
-require('jquery-ui/datepicker')
+require('jquery-ui/ui/widgets/datepicker')
 
 Vue.directive('datepicker', {
   bind: function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,9 +2880,9 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery-ui@1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.10.5.tgz#826aed3dd1f88d32ae75d74df48643dc431a5815"
+jquery-ui@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
 
 jquery@>=1.7.2, jquery@^2.2.4, jquery@x.*:
   version "2.2.4"


### PR DESCRIPTION
To address security vulnerability [1] (moderate severity) identified by
GitHub's dependency graph.

jQuery UI 1.12.0 introduced a reorg of the src directory [2, 3], so the
require in the datepicker directive now reflects this change.

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7103
[2] https://bugs.jqueryui.com/ticket/13885
[3] https://github.com/jquery/jquery-ui/commit/f1ce6e5