### PR TITLE
Fix erroneous filter name in events templates

### DIFF
--- a/vue/events/events-page/templates/events-template.html
+++ b/vue/events/events-page/templates/events-template.html
@@ -48,7 +48,7 @@
 				<div class="events__list">
 					<div class="event" v-for="event in events">
 						<h3 class="event__title">
-            	<a v-link="{ name: 'events', query: { eventId: event.event_id }}" v-on:click="setRecurringEventStartTime(event.event_start_time)" title="(((event.event_title))) [((date | momentHomeDateText))]">(((event.event_title)))</a>
+            	<a v-link="{ name: 'events', query: { eventId: event.event_id }}" v-on:click="setRecurringEventStartTime(event.event_start_time)" title="(((event.event_title))) [((date | momentDateText))]">(((event.event_title)))</a>
 						</h3>
 						<div class="event__details">
 


### PR DESCRIPTION
Most likely the result of copy/paste from `homepage-template.html`. We
really need to DRY things up by refactoring as suggested in #556.