### PR TITLE
Refactor study room availability (LibCal API v1.1)

### DIFF
--- a/app/views/snippets/room-availability-logic.liquid
+++ b/app/views/snippets/room-availability-logic.liquid
@@ -11,46 +11,76 @@
     {% assign room_param = "&room_id=" | append: room_id %}
     {% assign api_request_url = api_request_url | append: room_param%}
 
-    {% consume libcal_api from api_request_url, timeout: 5.0  %}
-      {% assign libcal_timeslots = libcal_api.availability.timeslots %}
-      {% for timeslot in libcal_timeslots %}
-        {% comment %} Now available {% endcomment %}
-        {% capture available_start_time %}{{timeslot.start | date: '%s'}}{% endcapture %}
-        {% capture available_end_time %}{{timeslot.end | date: '%s'}}{% endcapture %}
-        {% if available_start_time < current_time and available_end_time > current_time %}
-          {% assign available_icon = "fa-check-square" %}
-          {% assign room_availability = "Available" %}
-          {% assign room_available_icon = "fa-check" %}
+    {% comment %}
+      Use Locomotive Actions API to fetch data from LibCal
+      -- https://locomotive-v3.readme.io/v3.3/docs/external-api
+    {% endcomment %}
 
-          {% comment %} Break if loop {% endcomment %}
+    {% action "Fetch availability from LibCal" %}
+      const sensitiveData = getProp('site').metafields.sensitive_data
+      const clientId = sensitiveData.libcal_client_id
+      const clientSecret = sensitiveData.libcal_client_secret
+      const spaceId = getProp('room_id')
+      const apiUrl = 'https://api2.libcal.com/1.1/space/item/' + spaceId + '?availability'
+      var libcalAuth = false
+      var libcalAvailability = false
+
+      if (clientId && clientSecret) {
+        // Need to obtain access token first
+        libcalAuth = callAPI('POST', 'https://api2.libcal.com/1.1/oauth/token', {
+          data: {
+            client_id:     clientId,
+            client_secret: clientSecret,
+            grant_type:    'client_credentials'
+          }
+        })
+
+        // Now use access token to authenticate
+        if (libcalAuth) {
+          const token = 'Bearer ' + JSON.parse(libcalAuth.data).access_token
+
+          libcalAvailability = callAPI('GET', apiUrl, {
+            headers: {
+              authorization: token,
+              accept: 'application/json'
+            }
+          })
+        }
+
+        setProp('libcal_availability', libcalAvailability.data[0].availability)
+      }
+    {% endaction %}
+
+    {% for timeslot in libcal_availability %}
+      {% comment %} Now available {% endcomment %}
+      {% capture available_start_time %}{{timeslot.from | date: '%s'}}{% endcapture %}
+      {% capture available_end_time %}{{timeslot.to | date: '%s'}}{% endcapture %}
+
+      {% if available_start_time < current_time and available_end_time > current_time %}
+        {% assign available_icon = "fa-check-square" %}
+        {% assign room_availability = "Available" %}
+        {% assign room_available_icon = "fa-check" %}
+
+        {% comment %} Break if loop {% endcomment %}
+        {% break %}
+      {% comment %} Next available {% endcomment %}
+      {% elsif available_start_time > current_time %}
+        {% comment %}
+          Break elsif loop if next_available is less than next available_start_time
+          -- This logic works only for two rooms in a group
+        {% endcomment %}
+        {% if next_available and next_available < available_start_time %}
           {% break %}
-
-        {% comment %} Next available {% endcomment %}
-        {% elsif available_start_time > current_time %}
-
-          {% comment %}
-            Break elsif loop if next_available is less than next available_start_time
-            -- This logic works only for two rooms in a group
-          {% endcomment %}
-          {% if next_available and next_available < available_start_time %}
-            {% break %}
-          {% endif %}
-
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = available_start_time %}
-          {% assign room_availability = "Unavailable" %}
-          {% assign room_available_icon = "fa-times" %}
-
-          {% break %}
-
         {% endif %}
-      {% endfor %}
-    {% endconsume %}
 
-    {% comment %} If room is available, break out of for loop {% endcomment %}
-    {% if room_availability == "Available" %}
-      {% break %}
-    {% endif %}
+        {% assign available_icon = "fa-minus-square" %}
+        {% assign next_available = available_start_time %}
+        {% assign room_availability = "Unavailable" %}
+        {% assign room_available_icon = "fa-times" %}
+
+        {% break %}
+      {% endif %}
+    {% endfor %}
   {% endfor %}
 {% else %}
 {% comment %}

--- a/app/views/snippets/room-availability-variables.liquid
+++ b/app/views/snippets/room-availability-variables.liquid
@@ -62,7 +62,3 @@
     {% break %}
   {% endif %}
 {% endfor %}
-
-{% comment %} Build the Libcal request string using API key stored in site metafield {% endcomment %}
-{% assign api_request_url = 'https://api2.libcal.com/1.0/room_availability/?iid=973&key=' %}
-{% assign api_request_url = api_request_url | append: site.metafields.sensitive_data.libcal_apikey %}

--- a/config/metafields_schema.yml
+++ b/config/metafields_schema.yml
@@ -82,9 +82,6 @@ sensitive_data:
     labstats_customer_id:
       type: string
       hint: Used to authenticate against the LabStats API to retrieve real time desktop availability
-    libcal_apikey:
-      type: string
-      hint: Used to authenticate against the LibCal 1.0 API to retrieve room reservations via Room Booking Module
     libcal_client_id:
       label: LibCal Client ID
       type: string

--- a/config/site.yml
+++ b/config/site.yml
@@ -57,7 +57,6 @@ metafields:
     google_apikey:
     google_cse_id:
     labstats_customer_id:
-    libcal_apikey:
     libcal_client_id:
     libcal_client_secret:
     r25_webservice_authorization:


### PR DESCRIPTION
Necessary after migration to Equipment & Spaces module. Now using
Locomotive's Actions API in place of consume tag because it makes it
easier to obtain an access token via oAuth.

Remove api_key from site metafields since we're no longer hitting the
v1.0 endpoints of the LibCal API.