### PR TITLE
Bump to sprockets v3.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,6 @@ group :misc do
   # gem 'redcarpet', require: 'redcarpet'
   gem 'mann_liquid_extensions', :git => 'git@github.com:cul-it/mann_liquid_extensions', :tag => 'v1.3.0'
 end
+
+# Temp override of locomotivecms engine/steam dependency to address vulnerabilities
+gem 'sprockets', '~> 3.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4)
     sass (3.4.25)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     stringex (2.8.4)
@@ -187,6 +187,7 @@ DEPENDENCIES
   celluloid (= 0.16.0)
   locomotivecms_wagon (~> 2.4.0.rc2)
   mann_liquid_extensions!
+  sprockets (~> 3.7.2)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Which addresses the security vulnerability [1] (high severity)
identified by GitHub's dependency graph. This should cover us for now
until engine & steam are patched.

[1] https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k