### PR TITLE
Use LibCal room ID for unique modal id attrib #952

### DIFF
--- a/app/views/snippets/modal-libcal.liquid
+++ b/app/views/snippets/modal-libcal.liquid
@@ -1,4 +1,4 @@
-<div id="js-space-{{ space.reserve_sys_id }}" class="js-sui-modal ui fullscreen long modal scrolling">
+<div id="js-space-{{ space.reserve_sys_id }}-{{ space.reserve_sys_room_ids }}" class="js-sui-modal ui fullscreen long modal scrolling">
   <i class="close fa fa-times"></i>
   <div class="header">
     Reserve {{ space.name }}
@@ -7,6 +7,6 @@
   <iframe title="LibCal reservation form" src="{{ space.libcal_public_page_url}}" width="100%" height="625"></iframe>
 </div>
 
-<a class="js-modal-libcal ui labeled icon button space-finder__reserve js-spacefinder-link {% if indiv_space %}space__reserve{% endif %}" title="Reserve this space" data-spaceid="{{ space.reserve_sys_id }}">
+<a class="js-modal-libcal ui labeled icon button space-finder__reserve js-spacefinder-link {% if indiv_space %}space__reserve{% endif %}" title="Reserve this space" data-spaceid="{{ space.reserve_sys_id }}-{{ space.reserve_sys_room_ids }}">
 
 {{ 'modalLibcal.bundle.js' | javascript_tag }}


### PR DESCRIPTION
This addresses the double modal for conference & seminar rooms in the
space finder which resulted after shuffling all LibCal spaces into a
single location and grouping 100 and 102 into the same category.