### PR TITLE
Fix bug for lobby tabling LibCal modal

### DIFF
--- a/app/views/snippets/modal-libcal.liquid
+++ b/app/views/snippets/modal-libcal.liquid
@@ -1,4 +1,4 @@
-<div id="js-space-{{ space.reserve_sys_id }}-{{ space.reserve_sys_room_ids }}" class="js-sui-modal ui fullscreen long modal scrolling">
+<div id="js-space-{{ space.reserve_sys_id }}-{{ space.reserve_sys_room_ids | split: ',' | first }}" class="js-sui-modal ui fullscreen long modal scrolling">
   <i class="close fa fa-times"></i>
   <div class="header">
     Reserve {{ space.name }}
@@ -7,6 +7,6 @@
   <iframe title="LibCal reservation form" src="{{ space.libcal_public_page_url}}" width="100%" height="625"></iframe>
 </div>
 
-<a class="js-modal-libcal ui labeled icon button space-finder__reserve js-spacefinder-link {% if indiv_space %}space__reserve{% endif %}" title="Reserve this space" data-spaceid="{{ space.reserve_sys_id }}-{{ space.reserve_sys_room_ids }}">
+<a class="js-modal-libcal ui labeled icon button space-finder__reserve js-spacefinder-link {% if indiv_space %}space__reserve{% endif %}" title="Reserve this space" data-spaceid="{{ space.reserve_sys_id }}-{{ space.reserve_sys_room_ids | split: ',' | first }}">
 
 {{ 'modalLibcal.bundle.js' | javascript_tag }}


### PR DESCRIPTION
Introduced when fixing the original LibCal modal bug for 100/102 #953.
The original patch didn't account for the fact that we allow for
multiple room IDs in the spaces model (separated by comma and no space).

Addresses cul-it/mann-sitefeedback#206.