### PR TITLE
Closing double quote for id attribute

### DIFF
--- a/app/views/snippets/form-instruction-request.liquid
+++ b/app/views/snippets/form-instruction-request.liquid
@@ -30,7 +30,7 @@
 
     <div class="required field mann-form__compact">
       <label for="name">Name</label>
-      <input type="text" id="name name="content[name]" value="{{ instruction_request.name }}"">
+      <input type="text" id="name" name="content[name]" value="{{ instruction_request.name }}"">
     </div>
 
     <div class="required field mann-form__compact">


### PR DESCRIPTION
Address the regression introduced in WCAG remediation #883.

Fixes cul-it/mann-sitefeedback#251.