### PR TITLE
Hack to avoid Tumblr markup carryover into footer

### DIFF
--- a/app/views/snippets/dynamic-news.liquid
+++ b/app/views/snippets/dynamic-news.liquid
@@ -66,7 +66,7 @@
     <div class="news-latest__tumblr">
       <h5><a href="{{ latest_post.link }}" target="_blank" title="View our latest post on Tumblr">{{ latest_post.title }}</a></h5>
 
-      <p>{{ latest_post.description | truncatewords: 50 }}</p>
+      <div>{{ latest_post.description | remove: '<i>' | remove: '</i>' | truncatewords: 50 }}</div>
 
       <a href="{{ latest_post.link }}" target="_blank" title="View our latest post on Tumblr" aria-label="View our latest post on Tumblr">Read more <i class="fa fa-angle-double-right"></i></a>
     </div>


### PR DESCRIPTION
Far from elegant but a quick fix since I can't access Mann's Tumblr
account. Italcized footer on news page was reported by Tobi.