### PR TITLE
Remove McManus macs from desktop availability

### DIFF
--- a/app/views/snippets/accessory-desktops.liquid
+++ b/app/views/snippets/accessory-desktops.liquid
@@ -14,14 +14,11 @@
 
   {% consume mann_desktops from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60, timeout: 5.0  %}
     {% for location in mann_desktops.groups %}
-      {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
       {% case location.label %}
         {% when 'B30A' %}
           {% assign b30a = location %}
         {% when 'B30B' %}
           {% assign b30b = location %}
-        {% when 'McManus' %}
-          {% assign mcmanus = location %}
         {% when 'Research' %}
           {% assign research_win = location %}
         {% when 'Research Mac' %}
@@ -45,7 +42,7 @@
     {% capture basement_status %}<a href="{% path_to hours %}" title="View all hours"><span class="badge badge-error">Closed</span></a>{% endcapture %}
   {% endif %}
 
-  {% assign macs_avail = research_mac.available | plus: mcmanus.available %}
+  {% assign macs_avail = research_mac.available %}
 
   {% include 'availnow-desktops-template' %}
 

--- a/app/views/snippets/availnow-computers.liquid
+++ b/app/views/snippets/availnow-computers.liquid
@@ -21,14 +21,11 @@
 
   {% consume mann_computers from labstats_url, header_auth: site.metafields.sensitive_data.labstats_customer_id, expires_in: 60, timeout: 5.0 %}
     {% for location in mann_computers.groups %}
-      {% comment %} Waiting on Gabriel to add LabStats on the rest of the PCs & Macs in the farm, McManus, etc {% endcomment %}
       {% case location.label %}
         {% when 'B30A' %}
           {% assign b30a = location %}
         {% when 'B30B' %}
           {% assign b30b = location %}
-        {% when 'McManus' %}
-          {% assign mcmanus = location %}
         {% when 'Research' %}
           {% assign research_win = location %}
         {% when 'Research Mac' %}
@@ -52,7 +49,7 @@
     {% capture basement_status %}<a href="{% path_to hours %}" title="View all hours"><span class="badge badge-error">Closed</span></a>{% endcapture %}
   {% endif %}
 
-  {% assign macs_avail = research_mac.available | plus: mcmanus.available %}
+  {% assign macs_avail = research_mac.available %}
 
   {% include 'availnow-computers-template' %}
 

--- a/app/views/snippets/availnow-desktops-template.liquid
+++ b/app/views/snippets/availnow-desktops-template.liquid
@@ -8,12 +8,6 @@
   {% include 'availnow-computers-li' with location: 'Stone Center' os: 'apple', available: research_mac.available %}
 </ul>
 
-<h4 class="available-now__floor">Third Floor</h4>
-
-<ul>
-  {% include 'availnow-computers-li' with location: 'McManus Balcony', os: 'apple', available: mcmanus.available %}
-</ul>
-
 <h4 class="available-now__floor">Basement {% if basement_status %}{{ basement_status }}{% endif %}</h4>
 
 <ul>


### PR DESCRIPTION
They've been repurposed as kiosk and printing stations. Twelve new iMacs
have been deployed on the first floor during spring break, replacing
older models that were already there.

Overall the number of public iMacs have dropped significantly over the
past 8 months with the loss of the CIT Mac Lab and now McManus balcony.

> As per cul-it/mann-pac#85