### PR TITLE
Bump to jQuery v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "csvtojson": "^1.0.2",
     "formvalidation": "github:formvalidation/formvalidation",
-    "jquery": "~3.0.0",
+    "jquery": "~3.4.1",
     "jquery-ui": "1.12.1",
     "list.js": "^1.2.0",
     "semantic-ui-css": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2888,9 +2888,10 @@ jquery@>=1.7.2, jquery@x.*:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
 
-jquery@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.0.0.tgz#95a2a9541291a9f819e016f85ba247116d03e4ab"
+jquery@~3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"


### PR DESCRIPTION
To address security vulnerability [1] (moderate severity) identified by
GitHub's dependency graph.

[1] https://nvd.nist.gov/vuln/detail/CVE-2019-11358