### PR TITLE
Leverage categories for LibCal API space endpoint

### DIFF
--- a/app/views/snippets/room-availability-libcal.liquid
+++ b/app/views/snippets/room-availability-libcal.liquid
@@ -1,0 +1,87 @@
+{% comment %}
+  Use Locomotive Actions API to fetch data from LibCal
+  -- https://locomotive-v3.readme.io/v3.3/docs/external-api
+{% endcomment %}
+{% action "Fetch availability from LibCal" %}
+  const sensitiveData = getProp('site').metafields.sensitive_data
+  const clientId = sensitiveData.libcal_client_id
+  const clientSecret = sensitiveData.libcal_client_secret
+  const scope = getProp('scope')
+  const id = getProp('id')
+  const apiUrl = 'https://api2.libcal.com/1.1/space/' + scope + '/' + id + '?availability'
+  var libcalAuth = false
+  var libcalAvailability = false
+
+  if (clientId && clientSecret) {
+    // Need to obtain access token first
+    libcalAuth = callAPI('POST', 'https://api2.libcal.com/1.1/oauth/token', {
+      data: {
+        client_id:     clientId,
+        client_secret: clientSecret,
+        grant_type:    'client_credentials'
+      }
+    })
+
+    // Now use access token to authenticate
+    if (libcalAuth) {
+      const token = 'Bearer ' + JSON.parse(libcalAuth.data).access_token
+
+      libcalAvailability = callAPI('GET', apiUrl, {
+        headers: {
+          authorization: token,
+          accept: 'application/json'
+        }
+      })
+    }
+
+    //setProp('libcal_availability', libcalAvailability.data[0].availability)
+    setProp('libcal_response', libcalAvailability.data)
+  }
+{% endaction %}
+
+{% if scope == 'category' %}
+  {% assign available_list = libcal_response[0].items %}
+{% else %}
+  {% assign available_list = libcal_response %}
+{% endif %}
+
+{% comment %} {{ libcal_response }} {% endcomment %}
+{% comment %} {{ available_list }} {% endcomment %}
+
+
+{% for space in available_list %}
+  {% for timeslot in space.availability %}
+    {% comment %} Now available {% endcomment %}
+    {% capture available_start_time %}{{timeslot.from | date: '%s'}}{% endcapture %}
+    {% capture available_end_time %}{{timeslot.to | date: '%s'}}{% endcapture %}
+
+    {% if available_start_time < current_time and available_end_time > current_time %}
+      {% assign available_icon = "fa-check-square" %}
+      {% assign room_availability = "Available" %}
+      {% assign room_available_icon = "fa-check" %}
+
+      {% comment %} Break for loop {% endcomment %}
+      {% break %}
+    {% comment %} Next available {% endcomment %}
+    {% elsif available_start_time > current_time %}
+      {% comment %}
+        Determine next available_start_time
+      {% endcomment %}
+      {% if next_available %}
+        {% if next_available > available_start_time %}
+          {% assign next_available = available_start_time %}
+        {% endif %}
+      {% else %}
+        {% assign next_available = available_start_time %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% comment %} {% assign next_available = available_start_time %} {% endcomment %}
+{% endfor %}
+
+{% if room_availability != "Available" %}
+  {% assign available_icon = "fa-minus-square" %}
+  {% assign room_availability = "Unavailable" %}
+  {% assign room_available_icon = "fa-times" %}
+{% endif %}

--- a/app/views/snippets/room-availability-logic.liquid
+++ b/app/views/snippets/room-availability-logic.liquid
@@ -6,82 +6,29 @@
   {% assign next_available = nil %}
   {% assign available_time = nil %}
 
-  {% assign room_ids = space.reserve_sys_room_ids | split: "," %}
-  {% for room_id in room_ids %}
-    {% assign room_param = "&room_id=" | append: room_id %}
-    {% assign api_request_url = api_request_url | append: room_param%}
-
+  {% comment %} Dynamic request to LibCal API based on space metadata {% endcomment %}
+  {% if space.reserve_sys_room_ids %}
     {% comment %}
-      Use Locomotive Actions API to fetch data from LibCal
-      -- https://locomotive-v3.readme.io/v3.3/docs/external-api
+      If individual room IDs are specified:
+      -- Create array
+      -- Loop through array, making http request per room
     {% endcomment %}
+    {% assign scope = 'item' %}
+    {% assign room_ids = space.reserve_sys_room_ids | split: "," %}
 
-    {% action "Fetch availability from LibCal" %}
-      const sensitiveData = getProp('site').metafields.sensitive_data
-      const clientId = sensitiveData.libcal_client_id
-      const clientSecret = sensitiveData.libcal_client_secret
-      const spaceId = getProp('room_id')
-      const apiUrl = 'https://api2.libcal.com/1.1/space/item/' + spaceId + '?availability'
-      var libcalAuth = false
-      var libcalAvailability = false
-
-      if (clientId && clientSecret) {
-        // Need to obtain access token first
-        libcalAuth = callAPI('POST', 'https://api2.libcal.com/1.1/oauth/token', {
-          data: {
-            client_id:     clientId,
-            client_secret: clientSecret,
-            grant_type:    'client_credentials'
-          }
-        })
-
-        // Now use access token to authenticate
-        if (libcalAuth) {
-          const token = 'Bearer ' + JSON.parse(libcalAuth.data).access_token
-
-          libcalAvailability = callAPI('GET', apiUrl, {
-            headers: {
-              authorization: token,
-              accept: 'application/json'
-            }
-          })
-        }
-
-        setProp('libcal_availability', libcalAvailability.data[0].availability)
-      }
-    {% endaction %}
-
-    {% for timeslot in libcal_availability %}
-      {% comment %} Now available {% endcomment %}
-      {% capture available_start_time %}{{timeslot.from | date: '%s'}}{% endcapture %}
-      {% capture available_end_time %}{{timeslot.to | date: '%s'}}{% endcapture %}
-
-      {% if available_start_time < current_time and available_end_time > current_time %}
-        {% assign available_icon = "fa-check-square" %}
-        {% assign room_availability = "Available" %}
-        {% assign room_available_icon = "fa-check" %}
-
-        {% comment %} Break if loop {% endcomment %}
-        {% break %}
-      {% comment %} Next available {% endcomment %}
-      {% elsif available_start_time > current_time %}
-        {% comment %}
-          Break elsif loop if next_available is less than next available_start_time
-          -- This logic works only for two rooms in a group
-        {% endcomment %}
-        {% if next_available and next_available < available_start_time %}
-          {% break %}
-        {% endif %}
-
-        {% assign available_icon = "fa-minus-square" %}
-        {% assign next_available = available_start_time %}
-        {% assign room_availability = "Unavailable" %}
-        {% assign room_available_icon = "fa-times" %}
-
-        {% break %}
-      {% endif %}
+    {% for room_id in room_ids %}
+      {% include 'room-availability-libcal' with scope: scope, id: room_id  %}
     {% endfor %}
-  {% endfor %}
+  {% else %}
+    {% comment %}
+      If individual room IDs are NOT specified
+      -- Use the reserve_sys_id as category
+      -- Make single http request and retrieve availability for all rooms within category
+    {% endcomment %}
+    {% assign scope = 'category' %}
+
+    {% include 'room-availability-libcal' with scope: scope, id: space.reserve_sys_id %}
+  {% endif %}
 {% else %}
 {% comment %}
   MannServices Room Availability Logic

--- a/app/views/snippets/room-availability-logic.liquid
+++ b/app/views/snippets/room-availability-logic.liquid
@@ -108,66 +108,6 @@
           {% assign room_available_icon = "fa-times" %}
         {% endif %}
       {% endif %}
-    {% elsif space.name == "Large Group Study Rooms" %}
-      {% comment %} Now available {% endcomment %}
-      {% if large_group_room_now_available > "0" %}
-        {% assign available_icon = "fa-check-square" %}
-        {% assign room_availability = "Available" %}
-        {% assign room_available_icon = "fa-check" %}
-      {% else %}
-        {% comment %} Next available {% endcomment %}
-        {% if large_group_room_next_available %}
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = large_group_room_next_available %}
-          {% assign room_availability = "Unavailable" %}
-          {% assign room_available_icon = "fa-times" %}
-        {% else %}
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = nil %}
-          {% assign room_availability = "Overdue" %}
-          {% assign room_available_icon = "fa-times" %}
-        {% endif %}
-      {% endif %}
-    {% elsif space.name == "Small Group Study Rooms" %}
-      {% comment %} Now available {% endcomment %}
-      {% if small_group_room_now_available > "0" %}
-        {% assign available_icon = "fa-check-square" %}
-        {% assign room_availability = "Available" %}
-        {% assign room_available_icon = "fa-check" %}
-      {% else %}
-        {% comment %} Next available {% endcomment %}
-        {% if small_group_room_next_available %}
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = small_group_room_next_available %}
-          {% assign room_availability = "Unavailable" %}
-          {% assign room_available_icon = "fa-times" %}
-        {% else %}
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = nil %}
-          {% assign room_availability = "Overdue" %}
-          {% assign room_available_icon = "fa-times" %}
-        {% endif %}
-      {% endif %}
-    {% elsif space.name == "Individual Study Rooms" %}
-      {% comment %} Now available {% endcomment %}
-      {% if individual_room_now_available > "0" %}
-        {% assign available_icon = "fa-check-square" %}
-        {% assign room_availability = "Available" %}
-        {% assign room_available_icon = "fa-check" %}
-      {% else %}
-        {% comment %} Next available {% endcomment %}
-        {% if individual_room_next_available %}
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = individual_room_next_available %}
-          {% assign room_availability = "Unavailable" %}
-          {% assign room_available_icon = "fa-times" %}
-        {% else %}
-          {% assign available_icon = "fa-minus-square" %}
-          {% assign next_available = nil %}
-          {% assign room_availability = "Overdue" %}
-          {% assign room_available_icon = "fa-times" %}
-        {% endif %}
-      {% endif %}
     {% endif %}
   {% else %}
   {% comment %} Otherwise, library is closed so everything is unavailable {% endcomment %}

--- a/app/views/snippets/room-availability-variables.liquid
+++ b/app/views/snippets/room-availability-variables.liquid
@@ -8,26 +8,6 @@
       {% capture grad_room_due_dates %} {{ grad_room_due_dates }}-{{ due_dates | date: '%s'}}{% endcapture %}
     {% endfor %}
   {% endfor %}
-  {% assign large_group_room_now_available = mannservices_api.large_group_room_available %}
-  {% for large_group_rooms in mannservices_api.large_group_room_list | json %}
-    {% for due_dates in large_group_rooms.due_date %}
-      {% capture large_group_room_due_dates %} {{ large_group_room_due_dates }}-{{ due_dates | date: '%s' }}{% endcapture %}
-    {% endfor %}
-  {% endfor %}
-
-  {% assign small_group_room_now_available = mannservices_api.small_group_room_available %}
-  {% for small_group_rooms in mannservices_api.small_group_room_list | json %}
-    {% for due_dates in small_group_rooms.due_date %}
-      {% capture small_group_room_due_dates %} {{ small_group_room_due_dates }}-{{ due_dates | date: '%s' }}{% endcapture %}
-    {% endfor %}
-  {% endfor %}
-
-  {% assign individual_room_now_available = mannservices_api.individual_room_available %}
-  {% for individual_rooms in mannservices_api.individual_room_list | json %}
-    {% for due_dates in individual_rooms.due_date %}
-    {% capture individual_room_due_dates %} {{ individual_room_due_dates }}-{{ due_dates | date: '%s'}}{% endcapture %}
-    {% endfor %}
-  {% endfor %}
 {% endconsume %}
 
 {% comment %}Loop through due_date for each room, don't rely on *RoomNextAvailable{% endcomment %}
@@ -35,30 +15,6 @@
 {% for grad_room_due_date in grad_room_due_dates %}
   {% if grad_room_due_date > current_time %}
     {% assign grad_room_next_available = grad_room_due_date %}
-    {% break %}
-  {% endif %}
-{% endfor %}
-
-{% assign large_group_room_due_dates = large_group_room_due_dates | split: '-' | sort %}
-{% for large_group_room_due_date in large_group_room_due_dates %}
-  {% if large_group_room_due_date > current_time %}
-    {% assign large_group_room_next_available = large_group_room_due_date %}
-    {% break %}
-  {% endif %}
-{% endfor %}
-
-{% assign small_group_room_due_dates = small_group_room_due_dates | split: '-' | sort %}
-{% for small_group_room_due_date in small_group_room_due_dates %}
-  {% if small_group_room_due_date > current_time %}
-    {% assign small_group_room_next_available = small_group_room_due_date %}
-    {% break %}
-  {% endif %}
-{% endfor %}
-
-{% assign individual_room_due_dates = individual_room_due_dates | split: '-' | sort %}
-{% for individual_room_due_date in individual_room_due_dates %}
-  {% if individual_room_due_date > current_time %}
-    {% assign individual_room_next_available = individual_room_due_date %}
     {% break %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Limit to single http request to retrieve availability of spaces, even if
they are actually comprised of multiple rooms in LibCal.

Addresses #1008.

Most drastic example is individual study rooms (12 rooms total). This
PR reduces the number of http requests from up to 12 (depending on
availability) to 1, regardless of availability.

If individual room IDs are specified:

* Create array
* Loop through array, making http request per room

If individual room IDs are NOT specified

* Use the reserve_sys_id as category
* Make single http request and retrieve availability for all rooms
  within category

It should also be noted that this commit fixes the next availability bug
where the logic for determining the next available space fell apart when
dealing with more than two rooms (whether via a category or via listed
space IDs).