### PR TITLE
Add LibChat button to footer and adjust styling to match footer content

### DIFF
--- a/app/views/snippets/footer.liquid
+++ b/app/views/snippets/footer.liquid
@@ -79,8 +79,8 @@
         <a href="tel:+1607-255-3296" title="Call us">607-255-3296</a>
       </li>
       <li>
-        <span class="fa-li fa fa-comments"></span>
-        <a href="http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&page=frame&institution=10389&type=2&language=1" title="24/7 Chat" target="_blank">Chat with a Librarian</a>
+        <span class="fa-li fa fa-comment"></span>
+        <div id="libchat_d7ab5e7cb14cdb9891c00416e01551b4"></div>
       </li>
       <li>
         <span class="fa-li fa fa-map-marker"></span>
@@ -125,4 +125,5 @@
 
     <a class="footer__admin" href="https://admin.mannlib.cornell.edu/locomotive" title="Sign in to manage the site">Admin</a>
   </div>
+  {{ 'https://v2.libanswers.com/load_chat.php?hash=d7ab5e7cb14cdb9891c00416e01551b4' | javascript_tag }}
 </footer>

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -25,6 +25,14 @@
       color: color('white');
     }
   }
+  #libchat_d7ab5e7cb14cdb9891c00416e01551b4 button.libchat_online {
+    background: transparent;
+    color: color('action-footer');
+    font-weight: normal;
+    padding: 6px 0;
+    border: 0;
+    border-radius: 0;
+  }
 }
 
 .footer__about-subnav {


### PR DESCRIPTION
This changes the "Chat with a Librarian" link in the footer from QuestionPoint to the LibCal widget that was created instead. This widget created a button that says "Chat with us" that needed style adjustments to fit with the footer design. This PR adds that widget button into the Mann site footer and adjusts the styling of it.