### PR TITLE
Update course reserves and alert banner

### DIFF
--- a/app/views/snippets/dynamic-course-reserves.liquid
+++ b/app/views/snippets/dynamic-course-reserves.liquid
@@ -1,5 +1,5 @@
 {% comment %} Build the request string {% endcomment %}
-{% assign course_reserves_url = 'https://api.library.cornell.edu/LibServices/showCourseReserveList.do?library=MANN&output=json' %}
+{% assign course_reserves_url = 'https://coursereserves.library.cornell.edu/CourseReserves/showCourseReserveList?library=MANN' %}
 
 <div class="course-reserves">
   {% consume mann_reserves from course_reserves_url, expires_in: 3600  %}

--- a/app/views/snippets/footer.liquid
+++ b/app/views/snippets/footer.liquid
@@ -125,5 +125,7 @@
 
     <a class="footer__admin" href="https://admin.mannlib.cornell.edu/locomotive" title="Sign in to manage the site">Admin</a>
   </div>
+  <div id="libchat_85c16ce779fc1ab413219a49af71e80e"></div>
+  {{ 'https://v2.libanswers.com/load_chat.php?hash=85c16ce779fc1ab413219a49af71e80e' | javascript_tag }}
   {{ 'https://v2.libanswers.com/load_chat.php?hash=d7ab5e7cb14cdb9891c00416e01551b4' | javascript_tag }}
 </footer>

--- a/app/views/snippets/footer.liquid
+++ b/app/views/snippets/footer.liquid
@@ -79,8 +79,8 @@
         <a href="tel:+1607-255-3296" title="Call us">607-255-3296</a>
       </li>
       <li>
-        <span class="fa-li fa fa-comments"></span>
-        <a href="http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&page=frame&institution=10389&type=2&language=1" title="24/7 Chat" target="_blank">Chat with a Librarian</a>
+        <span class="fa-li fa fa-comment"></span>
+        <div id="libchat_d7ab5e7cb14cdb9891c00416e01551b4"></div>
       </li>
       <li>
         <span class="fa-li fa fa-map-marker"></span>
@@ -125,4 +125,5 @@
 
     <a class="footer__admin" href="https://admin.mannlib.cornell.edu/locomotive" title="Sign in to manage the site">Admin</a>
   </div>
+  {{ 'https://v2.libanswers.com/load_chat.php?hash=d7ab5e7cb14cdb9891c00416e01551b4' | javascript_tag }}
 </footer>

--- a/app/views/snippets/header.liquid
+++ b/app/views/snippets/header.liquid
@@ -81,12 +81,12 @@
   </div>
 
   {% if site.metafields.emergency_alert.active %}
-    <div class="ui violet message emergency-alert">
-      <div class="header">
+    <div class="ui message emergency-alert">
+      {% comment %}<div class="header">
         Special Alert
-      </div>
+      </div>{% endcomment %}
 
-      <p> {{ site.metafields.emergency_alert.alert_message }}</p>
+      <p>{{ site.metafields.emergency_alert.alert_message }}</p>
     </div>
   {% endif %}
 

--- a/src/scss/_shame.scss
+++ b/src/scss/_shame.scss
@@ -97,3 +97,14 @@ table.software-list__table {
 .mannlib-hidden {
   display: none;
 }
+
+// Override of emergency alert banner to fit the style on all other unit sites - no current options matched well enough
+.ui.message {
+  background-color: #fcf8e3;
+  color: #0068ac;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: bold;
+  text-align: center;
+}

--- a/src/scss/_shame.scss
+++ b/src/scss/_shame.scss
@@ -105,6 +105,8 @@ table.software-list__table {
   border: 0;
   border-radius: 0;
   box-shadow: none;
-  font-weight: bold;
   text-align: center;
+  a, a:visited, a:focus, a:active {
+    color: #0068ac;
+  }
 }

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -25,6 +25,14 @@
       color: color('white');
     }
   }
+  #libchat_d7ab5e7cb14cdb9891c00416e01551b4 button.libchat_online {
+    background: transparent;
+    color: color('action-footer');
+    font-weight: normal;
+    padding: 6px 0;
+    border: 0;
+    border-radius: 0;
+  }
 }
 
 .footer__about-subnav {

--- a/vue/course-reserves/components/reserve-item.html
+++ b/vue/course-reserves/components/reserve-item.html
@@ -10,9 +10,10 @@
     (( item.callnumber ))
   </td>
   <td>
-    <a v-if="item.online" href="https://blackboard.cornell.edu" title="Sign in to Blackboard to retrieve this electronic resource" target="_blank">(( item.dueDate ))</a>
+    <a v-if="item.online" href="https://canvas.cornell.edu" title="Sign in to Canvas to retrieve this electronic resource" target="_blank">(( item.dueDate ))</a>
     <span v-if="item.dueDate === 'Available'" class="badge badge-success">(( item.dueDate ))</span>
     <span v-if="item.checkedOut" class="badge badge-error">(( item.formattedDueDate ))</span>
+    <span v-if="item.dueDate === 'CURRENTLY UNAVAILABLE DUE TO LIBRARY CLOSURE'">(( item.dueDate ))</span>
     <template v-if="item.overdue">
       <span class="badge badge-danger">Overdue</span>
       <span class="course-reserves__overdue">(( item.formattedDueDate ))</span>

--- a/vue/course-reserves/components/reserve-item.html
+++ b/vue/course-reserves/components/reserve-item.html
@@ -7,7 +7,7 @@
   <td>(( item.author ))</td>
   <td>
     <em v-if="item.elsewhere" class="course-reserves__location--not-mann" >(( item.location ))</em>
-    (( item.callnumber ))
+    <span v-if="item.callnumber !== 'networked resource'">(( item.callnumber ))</span>
   </td>
   <td>
     <a v-if="item.online" href="https://canvas.cornell.edu" title="Sign in to Canvas to retrieve this electronic resource" target="_blank">(( item.dueDate ))</a>

--- a/vue/course-reserves/components/reserve-item.vue
+++ b/vue/course-reserves/components/reserve-item.vue
@@ -27,8 +27,13 @@
           this.$set('item.elsewhere', true)
         }
 
+        // If "CURRENTLY UNAVAILABLE DUE TO LIBRARY CLOSURE"
+        if (this.item.dueDate == 'CURRENTLY UNAVAILABLE DUE TO LIBRARY CLOSURE') {
+          this.$set('item.dueDate', 'CURRENTLY UNAVAILABLE DUE TO LIBRARY CLOSURE')
+        }
+
         // Use Moment to format due date of unavailable items
-        if (this.item.dueDate !== 'Available' && this.item.dueDate !== 'Online' && this.item.location !== '?') {
+        if (this.item.dueDate !== 'Available' && this.item.dueDate !== 'CURRENTLY UNAVAILABLE DUE TO LIBRARY CLOSURE' && this.item.dueDate !== 'Online' && this.item.location !== '?') {
           var due = moment(this.item.dueDate)
           var dueRelative = due.calendar()
 

--- a/vue/course-reserves/course-reserves.js
+++ b/vue/course-reserves/course-reserves.js
@@ -38,7 +38,7 @@ var vm = new Vue({
   methods: {
     getReserveItems () {
       if (this.selectedCourse) {
-        var reservesApiBaseUrl = 'https://api.library.cornell.edu/LibServices/showCourseReserveItemInfo.do?output=json&courseid='
+        var reservesApiBaseUrl = 'https://coursereserves.library.cornell.edu/CourseReserves/showCourseReserveItemInfo?courseid='
         var reservesApiUrl = reservesApiBaseUrl + this.selectedCourse
 
         this.toggleLoader()


### PR DESCRIPTION
Only show call number if not 'networked resource'
Update course reserves template to display currently unavailable message
Update course reserves URL to new service
Update link color, remove hard-coded bold
Update alert banner to match all other unit sites