### PR TITLE
Ensure LibCal events array is marked as updated

### DIFF
--- a/vue/events/events-page/components/Events.vue
+++ b/vue/events/events-page/components/Events.vue
@@ -832,11 +832,11 @@ export default {
             }
           })
         })
-        // Set array values to be used later to merge
-        this.$set('libcalEvents', libcalEvents)
-        this.$set('libcalEventTypes', eventTypes)
-        this.$set('libcalRoomNames', roomNames)
       }
+      // Set array values to be used later to merge
+      this.$set('libcalEvents', libcalEvents)
+      this.$set('libcalEventTypes', eventTypes)
+      this.$set('libcalRoomNames', roomNames)
     },
     // Custom data model from r25 events
     r25EventsArray (data) {

--- a/vue/events/homepage-events/components/HomepageEvents.vue
+++ b/vue/events/homepage-events/components/HomepageEvents.vue
@@ -563,10 +563,9 @@ export default {
           }
         }
       })
-      if (vueInstance.libcalReservations.length) {
-        // Set array values to be used later to merge
-        this.$set('libcalEvents', libcalEvents)
-      }
+
+      // Set array values to be used later to merge
+      this.$set('libcalEvents', libcalEvents)
     },
     // Custom data model from r25 events
     r25EventsArray (data) {


### PR DESCRIPTION
Even if there are no upcoming events, the empty result set needs to be
stored to the libcalEvents array since it is being watched [1] to
indicate that the fetch is complete.

This step was inside a test for array length and normally wouldn't
present as an issue since it is unlikely we would have no LibCal
reservations in the next 35 days, but these are unusual times.

It should be noted that this resulted in a broken state of the Events
calendar (forever loading) which was mistakenly attributed to the May
2020 ADDTrust External CA Root Expiration [2], but this is unrelated and
simply unfortunate timing.

[1]: https://v1.vuejs.org/api/#watch
[2]: https://calnetweb.berkeley.edu/calnet-technologists/incommon-sectigo-certificate-service/addtrust-external-root-expiration-may-2020#affected