### PR TITLE
Add header to locomotive actions call for search

### DIFF
--- a/app/views/snippets/site-search.liquid
+++ b/app/views/snippets/site-search.liquid
@@ -17,7 +17,11 @@
   var searchResults = false
 
   if (apiKey && cseId) {
-    searchResults = callAPI('GET', apiUrl, {})
+    searchResults = callAPI('GET', apiUrl, {
+      headers: {
+        referer: 'https://mannlib.cornell.edu/search'
+      }
+    })
 
     if (searchResults.status === 200) {
       setProp('search_results', searchResults.data)


### PR DESCRIPTION
Use the headers option [1] for callAPI() from the actions API combined
with an HTTP restriction [2] on the API key used for accessing the
Google Custom Search JSON API to help prevent unauthorized use and
quota theft.

This appears to address the situation for now, although usage of this
key has been suspiciously high to do GCP console metrics, so if that
continues, the next step is to regenerate the key.

Resolves cul-it/mann-sitefeedback#787

[1]: https://doc.locomotivecms.com/v3.4/docs/external-api#options
[2]: https://cloud.google.com/docs/authentication/api-keys#adding_http_restrictions