### PR TITLE
Bump mann liquid drops to v1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :misc do
   # Add your extra gems here
   # gem 'susy', require: 'susy'
   # gem 'redcarpet', require: 'redcarpet'
-  gem 'mann_liquid_extensions', :git => 'git@github.com:cul-it/mann_liquid_extensions', :tag => 'v1.4.0'
+  gem 'mann_liquid_extensions', :git => 'git@github.com:cul-it/mann_liquid_extensions', :tag => 'v1.5.0'
 end
 
 # Temp override of locomotivecms engine/steam dependency to address vulnerabilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:cul-it/mann_liquid_extensions
-  revision: 1d9de52a2ab12e141f99ea9acb42a7f6aa82449c
-  tag: v1.4.0
+  revision: a78709fcab3029ac907bed241c935f761cf37c68
+  tag: v1.5.0
   specs:
     mann_liquid_extensions (1.4.0)
 


### PR DESCRIPTION
Support text status for LibCal hours in prep for limited services rolling out 2020-07-01 in response to COVID-19 pandemic.