### PR TITLE
A11Y: Ensure min color contrast for accessory nav

### DIFF
--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -143,8 +143,7 @@ $colors: (
 
   // Nav
   'accessory-nav': 'white',
-  'accessory-nav-hover': 'ocean-green',
-  'accessory-nav-icon': 'deep-lemon',
+  'accessory-nav-icon': 'blond',
   'accessory-nav-bg': 'cornell-gray',
   'accessory-nav-btn': 'cornell-gray',
   'my-account': 'cornell-gray',

--- a/src/scss/layout/_nav.scss
+++ b/src/scss/layout/_nav.scss
@@ -73,7 +73,8 @@
   font-weight: normal;
 
   &:hover {
-    color: color('accessory-nav-hover');
+    color: color('accessory-nav');
+    text-decoration: underline; 
   }
 }
 
@@ -154,7 +155,8 @@
     color: color('my-account-mobile');
 
     &:hover {
-      color: color('accessory-nav-hover');
+      color: color('accessory-nav');
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
[1.4.3 Color contrast is insufficient](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)

> As reported in cul-it/uls#866.