### PR TITLE
Internal floormaps in footer with sibling nav

### DIFF
--- a/app/views/pages/.gitignore
+++ b/app/views/pages/.gitignore
@@ -22,6 +22,9 @@
 # Track pages that supplement/provide content programatically
 !404.liquid
 !about/staff.liquid
+!about/floors/basement.liquid
+!about/floors/first.liquid
+!about/floors/second.liquid
 !/course-reserves.liquid # Be specific here due to redirect with same filename at use/borrow-request-renew/course-reserves.liquid
 !help/faculty-instructors/find-your-librarian.liquid
 !help/faculty-instructors/request-course-instruction.liquid

--- a/app/views/pages/about/floors/basement.liquid
+++ b/app/views/pages/about/floors/basement.liquid
@@ -14,3 +14,7 @@ editable_elements:
   main/page_content: <p><img title="mann-floorplan-basement.png" alt="undefined" src="/samples/assets/mann-floorplan-basement.png"><br></p>
 ---
 {% extends "layouts/basic-page" %}
+
+{% block 'main/accessory' %}
+  {% include 'nav-siblings' %}
+{% endblock %}

--- a/app/views/pages/about/floors/basement.liquid
+++ b/app/views/pages/about/floors/basement.liquid
@@ -1,0 +1,16 @@
+---
+title: Basement
+slug: basement
+handle: basement
+position: 0
+listed: true
+published: true
+is_layout: false
+editable_elements:
+  alert/alert_enabled?: 'false'
+  alert/alert_body: ''
+  "/alert_enabled?": 'false'
+  "/alert_body": ''
+  main/page_content: <p><img title="mann-floorplan-basement.png" alt="undefined" src="/samples/assets/mann-floorplan-basement.png"><br></p>
+---
+{% extends "layouts/basic-page" %}

--- a/app/views/pages/about/floors/first.liquid
+++ b/app/views/pages/about/floors/first.liquid
@@ -1,0 +1,14 @@
+---
+title: First Floor
+slug: first
+handle: first-floor
+position: 1
+listed: true
+published: true
+is_layout: false
+editable_elements:
+  main/page_content: <img title="mann-floorplan-first.png" alt="undefined" src="/samples/assets/mann-floorplan-first.png"><br>
+  alert/alert_enabled?: 'false'
+  alert/alert_body: ''
+---
+{% extends "layouts/basic-page" %}

--- a/app/views/pages/about/floors/first.liquid
+++ b/app/views/pages/about/floors/first.liquid
@@ -12,3 +12,7 @@ editable_elements:
   alert/alert_body: ''
 ---
 {% extends "layouts/basic-page" %}
+
+{% block 'main/accessory' %}
+  {% include 'nav-siblings' %}
+{% endblock %}

--- a/app/views/pages/about/floors/second.liquid
+++ b/app/views/pages/about/floors/second.liquid
@@ -1,0 +1,14 @@
+---
+title: Second Floor
+slug: second
+handle: second-floor
+position: 2
+listed: true
+published: true
+is_layout: false
+editable_elements:
+  main/page_content: <p><img title="mann-floorplan-second.png" alt="undefined" src="/samples/assets/mann-floorplan-second.png"><br></p>
+  alert/alert_enabled?: 'false'
+  alert/alert_body: ''
+---
+{% extends "layouts/basic-page" %}

--- a/app/views/pages/about/floors/second.liquid
+++ b/app/views/pages/about/floors/second.liquid
@@ -12,3 +12,7 @@ editable_elements:
   alert/alert_body: ''
 ---
 {% extends "layouts/basic-page" %}
+
+{% block 'main/accessory' %}
+  {% include 'nav-siblings' %}
+{% endblock %}

--- a/app/views/snippets/footer.liquid
+++ b/app/views/snippets/footer.liquid
@@ -14,24 +14,14 @@
       {% endfor %}
     </ul>
 
-    <h5 class="footer__heading"><a class="footer__heading-link" href="http://smartmap.mannlib.cornell.edu" title="Mann Library SmartMap" target="_blank">Floor Plans</a></h5>
+    <h5 class="footer__heading"><a class="footer__heading-link" href="{% path_to floorplans %}" title="View our building maps">Floor Plans</a></h5>
 
-    <ul>
-      <li>
-        <a href="http://smartmap.mannlib.cornell.edu/floor/0" title="Basement floor plan" target="_blank">Basement</a>
-      </li>
-      <li>
-        <a href="http://smartmap.mannlib.cornell.edu/floor/1" title="First floor, floor plan" target="_blank">1st</a>
-      </li>
-      <li>
-        <a href="http://smartmap.mannlib.cornell.edu/floor/2" title="Second floor, floor plan" target="_blank">2nd</a>
-      </li>
-      {% comment %}
-        Third floor will is closed for Fall 2020 (COVID-19)
-      {% endcomment %}
-      {% comment %} <li>
-        <a href="http://smartmap.mannlib.cornell.edu/floor/3" title="Third floor, floor plan" target="_blank">3rd</a>
-      </li> {% endcomment %}
+    {% comment %} About Us subnav with child pages {% endcomment %}
+    {% with_scope handle: 'floorplans' %}{% assign floorplans_page = site.pages.first %}{% endwith_scope %}
+    <ul class="footer__about-subnav">
+      {% for child in floorplans_page.children %}
+        <li><a href="{% path_to child %}" title="{{ child.title }}">{{ child.title }}</a></li>
+      {% endfor %}
     </ul>
   </div>
 

--- a/app/views/snippets/nav-siblings.liquid
+++ b/app/views/snippets/nav-siblings.liquid
@@ -1,0 +1,14 @@
+<nav aria-label="Project navigation">
+  <h4 class="parent-section">{{ page.parent.title }}</h4>
+
+  <ul>
+    {% for sibling in page.parent.children %}
+      {% if sibling.listed? and sibling.published? %}
+        <li>
+          {% comment %} Re-use nav-snippet for section nav by passing sibling as page {% endcomment %}
+          {% include 'nav-section-builder' with page: sibling %}
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</nav>


### PR DESCRIPTION
Dropping the smartmap in favor of local pages during Fall 2020 and quiet
study in the times of COVID-19.

We still have MapIt links to the smartmap littered throughout the site
and we're good with that. The smartmap isn't going anywhere (just yet).

> Resolves #1073