### PR TITLE
Bugfix: Ensure Localist events are rendered

### DIFF
--- a/vue/events/events-page/components/Events.vue
+++ b/vue/events/events-page/components/Events.vue
@@ -245,7 +245,7 @@ export default {
       // console.log(error.status, error.statusText, error.request.url);
       this.apiErrors.push(service)
       if (this.apiErrors.length === 3) {
-        this.$set('noEventsMessage', 'Something went wrong while getting upcoming events, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+        this.$set('noEventsMessage', 'Something went wrong while getting upcoming events, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
       }
     },
     toggleAcademicCourses (status) {
@@ -418,7 +418,7 @@ export default {
             }
           }).catch(function(error){
             vueInstance.setLibCalEvents(option, 'error')
-            vueInstance.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+            vueInstance.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
             vueInstance.$set('errorLibcalEvents', error)
             vueInstance.$set('eventSources.updatedLibcalEvents', true)
           })
@@ -545,7 +545,7 @@ export default {
             }).catch(function(error){
               vueInstance.eventArray('Error')
               vueInstance.$set('errorR25Event', error)
-              this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+              this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
             })
         }
       }
@@ -934,7 +934,7 @@ export default {
       }).catch(function(error){
         vueInstance.eventArray('Error')
         vueInstance.$set('errorCornellEvent', error)
-        this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+        this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
       })
     },
     eventArray (source, data) {

--- a/vue/events/events-page/components/Events.vue
+++ b/vue/events/events-page/components/Events.vue
@@ -673,7 +673,7 @@ export default {
         events['event_start_time'] = value.event_instances[0].event_instance.start
         events['event_start'] = value.event_instances[0].event_instance.start.substring(0, 10)
         events['event_end_time'] = value.event_instances[0].event_instance.end
-        if (value.room_number != '') {
+        if (value.room_number) {
           events['event_room_name'] = value.room_number.trim().replace(',', '')
         } else if (value.location_name != '') {
           events['event_room_name'] = value.location_name.trim().replace(',', '')
@@ -708,7 +708,7 @@ export default {
         cornellEvents.push(events)
 
         // Room filter list array
-        if (value.room_number != '') {
+        if (value.room_number) {
           if (roomNames.indexOf(value.room_number.trim().replace(',', '')) === -1) {
             roomNames.push(value.room_number.trim().replace(',', ''))
           }

--- a/vue/events/events-page/components/Events.vue
+++ b/vue/events/events-page/components/Events.vue
@@ -675,7 +675,7 @@ export default {
         events['event_end_time'] = value.event_instances[0].event_instance.end
         if (value.room_number) {
           events['event_room_name'] = value.room_number.trim().replace(',', '')
-        } else if (value.location_name != '') {
+        } else if (value.location_name) {
           events['event_room_name'] = value.location_name.trim().replace(',', '')
         }
         _.forEach(vueInstance.curatedEventLocations, function(curatedEventLocation, index) {
@@ -712,7 +712,7 @@ export default {
           if (roomNames.indexOf(value.room_number.trim().replace(',', '')) === -1) {
             roomNames.push(value.room_number.trim().replace(',', ''))
           }
-        } else if (value.location_name != '') {
+        } else if (value.location_name) {
           if (roomNames.indexOf(value.location_name.trim().replace(',', '')) === -1) {
             roomNames.push(value.location_name.trim().replace(',', ''))
           }
@@ -988,9 +988,9 @@ export default {
           })
         })
         var location = ''
-        if (data.room_number !== '') {
+        if (data.room_number) {
           location = data.room_number.trim().replace(',', '')
-        } else if (data.location_name != '') {
+        } else if (data.location_name) {
           location = data.location_name.trim().replace(',', '')
         }
         _.forEach(vueInstance.curatedEventLocations, function(curatedEventLocation, index) {

--- a/vue/events/homepage-events/components/HomepageEvents.vue
+++ b/vue/events/homepage-events/components/HomepageEvents.vue
@@ -185,7 +185,7 @@ export default {
       // console.log(error.status, error.statusText, error.request.url);
       this.apiErrors.push(service)
       if (this.apiErrors.length === 3) {
-        this.$set('noEventsMessage', 'Something went wrong while getting upcoming events, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+        this.$set('noEventsMessage', 'Something went wrong while getting upcoming events, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
       }
     },
     displayEventList () {
@@ -327,7 +327,7 @@ export default {
           this.setLibCalEvents(option, param)
         }).catch(function(error){
           vueInstance.setLibCalEvents(option, 'error')
-          vueInstance.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+          vueInstance.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
           vueInstance.$set('errorLibcalEvents', error)
           vueInstance.$set('eventSources.updatedLibcalEvents', true)
         })
@@ -433,7 +433,7 @@ export default {
             }).catch(function(error){
               vueInstance.eventArray('Error')
               vueInstance.$set('errorR25Event', error)
-              this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+              this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
             })
         }
       }
@@ -620,7 +620,7 @@ export default {
       }).catch(function(error){
         vueInstance.eventArray('Error')
         vueInstance.$set('errorCornellEvent', error)
-        this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/contact/site-feedback">Report this issue.</a>')
+        this.$set('noSingleEventMessage', 'Something went wrong while getting the event, please try again later. <br><a href="/site-feedback">Report this issue.</a>')
       })
     },
     eventArray (source, data) {

--- a/vue/events/homepage-events/components/HomepageEvents.vue
+++ b/vue/events/homepage-events/components/HomepageEvents.vue
@@ -465,7 +465,7 @@ export default {
         events['event_end_time'] = value.event_instances[0].event_instance.end
         if (value.room_number) {
           events['event_room_name'] = value.room_number.trim().replace(',', '')
-        } else if (value.location_name != '') {
+        } else if (value.location_name) {
           events['event_room_name'] = value.location_name.trim().replace(',', '')
         }
         _.forEach(vueInstance.curatedEventLocations, function(curatedEventLocation, index) {
@@ -674,9 +674,9 @@ export default {
           })
         })
         var location = ''
-        if (data.room_number !== '') {
+        if (data.room_number) {
           location = data.room_number.trim().replace(',', '')
-        } else if (data.location_name != '') {
+        } else if (data.location_name) {
           location = data.location_name.trim().replace(',', '')
         }
         _.forEach(vueInstance.curatedEventLocations, function(curatedEventLocation, index) {

--- a/vue/events/homepage-events/components/HomepageEvents.vue
+++ b/vue/events/homepage-events/components/HomepageEvents.vue
@@ -463,7 +463,7 @@ export default {
         events['event_start_time'] = value.event_instances[0].event_instance.start
         events['event_start'] = value.event_instances[0].event_instance.start.substring(0, 10)
         events['event_end_time'] = value.event_instances[0].event_instance.end
-        if (value.room_number != '') {
+        if (value.room_number) {
           events['event_room_name'] = value.room_number.trim().replace(',', '')
         } else if (value.location_name != '') {
           events['event_room_name'] = value.location_name.trim().replace(',', '')


### PR DESCRIPTION
The underlying issue was that we were testing that the `room_number` was not an empty string when we should have been testing for _truthy_ to ensure we catch NULL values as well.

@sew268 @eeh53 aka...[events are back](https://mannlib.cornell.edu/news-events/events/calendar)!