### PR TITLE
Remove CU emergency banner

### DIFF
--- a/app/views/pages/layouts/default.liquid
+++ b/app/views/pages/layouts/default.liquid
@@ -49,7 +49,5 @@ is_layout: false
     </main>
 
     {% include 'footer' %}
-
-    <script src="https://embanner.univcomm.cornell.edu/OWC-emergency-banner.js" type="text/javascript" async></script>
   </body>
 </html>


### PR DESCRIPTION
University communications [just announced](https://brand.cornell.edu/messaging/emergency-banner/) that it will be deprecated on `2021-03-31`.